### PR TITLE
Some semantic check and exception catching for more robustness 

### DIFF
--- a/src/ekf_localization_component.cpp
+++ b/src/ekf_localization_component.cpp
@@ -122,6 +122,7 @@ EkfLocalizationComponent::EkfLocalizationComponent(const rclcpp::NodeOptions & o
         }
         if (param.get_name() == "pub_period") {
           if (pub_period_ > 0) {
+            pub_period_ = param.as_int();
             results->successful = true;
             results->reason = "";
           } else {

--- a/src/ekf_localization_component.cpp
+++ b/src/ekf_localization_component.cpp
@@ -120,6 +120,15 @@ EkfLocalizationComponent::EkfLocalizationComponent(const rclcpp::NodeOptions & o
             results->reason = "var_gnss_z must over 0";
           }
         }
+        if (param.get_name() == "pub_period") {
+          if (pub_period_ > 0) {
+            results->successful = true;
+            results->reason = "";
+          } else {
+            results->successful = false;
+            results->reason = "pub_period must over 0";
+          }
+        }
       }
       if (!results->successful) {
         results->successful = false;
@@ -190,6 +199,9 @@ EkfLocalizationComponent::EkfLocalizationComponent(const rclcpp::NodeOptions & o
           transformed_msg.linear_acceleration.z = acc_out.vector.z;
           predictUpdate(transformed_msg);
         } catch (tf2::TransformException & e) {
+          RCLCPP_ERROR(this->get_logger(), "%s", e.what());
+          return;
+        } catch (std::runtime_error & e) {
           RCLCPP_ERROR(this->get_logger(), "%s", e.what());
           return;
         }


### PR DESCRIPTION
---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Primary OS tested on | Ubuntu20.04 |
| Robotic platform tested on | gazebo simulation of turtlebot3 |

---

## Description of the bugs

Hi, I'm researching on testing ROS program and improve the robustness of programs facing possible malformed inputs. There are several improvements can be made for a more robust running. 

There are two possible bugs with malformed user input:

First, there is no check for the `pub_period`, if a negative or zero value is set to the period, there will be a crash throwing the error `'std::invalid_argument'` when set the publisher:

```
  std::chrono::milliseconds period(pub_period_);
  timer_ = create_wall_timer(
    std::chrono::duration_cast<std::chrono::nanoseconds>(period),
    std::bind(&EkfLocalizationComponent::broadcastPose, this));
```

crash info:
```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  timer period cannot be negative
```

Second, there is a possibility that the timestamp of the pose message can be negative because of malfunction or intentional design. And there will be an exception `'std::runtime_error'` when set the value to a `TimePoint`:

```
auto imu_callback =
    [this](const typename sensor_msgs::msg::Imu::SharedPtr msg) -> void
    {
     ...
     tf2::TimePoint time_point = tf2::TimePoint(
     std::chrono::seconds(msg->header.stamp.sec) +
     std::chrono::nanoseconds(msg->header.stamp.nanosec));
    ...
   }
```

crash info:
```
[INFO] [1668342157.570762430] [loc2d_ros]: New laser configured (id=0 frame_id=base_scan)
terminate called after throwing an instance of 'std::runtime_error'
  what():  cannot store a negative time point in rclcpp::Time
```

Therefore, I add a senmantic check for `pub_period` as the same as the other params, and catch the exception in the `imu_callback`. Hope you can accept the PRs.
