### PR TITLE
Add robust localization research ablations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 build/
 install/
 log/
+.data/

--- a/README.md
+++ b/README.md
@@ -28,15 +28,84 @@ Output:
 | `publish_tf` | bool | false | Publish the estimated reference-to-robot transform |
 | `var_gnss_xy` | double | 0.1 | GNSS position variance in XY `[m^2]` |
 | `var_gnss_z` | double | 0.15 | GNSS position variance in Z `[m^2]` |
+| `gnss_position_robust_loss` | string | `none` | Soft robust loss: `none`, `huber`, or `cauchy` |
+| `gnss_position_robust_tuning` | double | 2.5 | Robust loss transition in normalized residual units |
+| `max_gnss_position_robust_variance_scale` | double | 100.0 | Maximum robust covariance multiplier |
+
+The optional robust loss uses `sqrt(NIS)` as a normalized residual. Huber increases
+measurement covariance linearly beyond the tuning constant, while Cauchy increases it
+quadratically. Hard innovation/NIS gates still take precedence; robust scaling handles
+the measurements that remain inside those gates without an accept/reject discontinuity.
 | `gnss_input_type` | string | `pose` | GNSS input type: `pose` or `navsatfix` |
 | `gnss_pose_topic` | string | `gnss_pose` | `PoseStamped` GNSS input topic |
 | `gnss_navsatfix_topic` | string | `/gnss/fix` | `NavSatFix` GNSS input topic when `gnss_input_type: "navsatfix"` |
 | `gnss_navsatfix_use_first_fix_as_origin` | bool | true | Use the first valid `NavSatFix` as the local ENU origin |
+| `gnss_navsatfix_use_position_covariance` | bool | false | Use per-message NavSatFix ENU covariance |
+| `gnss_navsatfix_min_variance_xy` | double | 0.0001 | XY variance floor `[m^2]` |
+| `gnss_navsatfix_min_variance_z` | double | 0.0001 | Z variance floor `[m^2]` |
+| `gnss_navsatfix_max_variance_xy` | double | 100.0 | XY variance ceiling `[m^2]` |
+| `gnss_navsatfix_max_variance_z` | double | 100.0 | Z variance ceiling `[m^2]` |
+| `gnss_lever_arm_x` | double | 0.0 | GNSS antenna X offset from body/IMU origin `[m]` |
+| `gnss_lever_arm_y` | double | 0.0 | GNSS antenna Y offset from body/IMU origin `[m]` |
+| `gnss_lever_arm_z` | double | 0.0 | GNSS antenna Z offset from body/IMU origin `[m]` |
+| `compensate_gnss_delay` | bool | false | Extrapolate delayed GNSS position to the latest IMU time |
+| `gnss_time_offset_sec` | double | 0.0 | Offset added to the GNSS message timestamp `[s]` |
+| `max_gnss_delay_compensation_sec` | double | 0.5 | Reject observations older than this limit `[s]` |
 | `var_odom_xyz` | double | 0.1 | Odometry variance `[m^2]` |
 | `var_imu_w` | double | 0.01 | Angular velocity variance `[(deg/sec)^2]` |
 | `var_imu_acc` | double | 0.01 | Accelerometer variance `[(m/sec^2)^2]` |
+| `use_continuous_process_noise_density` | bool | false | Interpret IMU noise parameters as continuous PSDs |
+| `use_second_order_state_transition` | bool | false | Use a second-order continuous-to-discrete state transition |
+| `use_second_order_process_noise` | bool | false | Propagate continuous noise into coupled states |
 | `use_gnss` | bool | true | Whether GNSS is used |
 | `use_odom` | bool | false | Whether odometry is used |
+
+When `use_continuous_process_noise_density` is enabled, `var_imu_acc` and
+`var_imu_w` are treated as continuous-time power spectral densities and discretized
+with `Qd = Qc * dt`. This makes covariance growth substantially independent of the IMU
+sampling rate. The default remains disabled to preserve existing tuned profiles that
+use the legacy per-sample `dt^2` convention.
+
+`use_second_order_state_transition` constructs a continuous-time error-state Jacobian
+and applies `Phi = I + Fc*dt + 0.5*(Fc*dt)^2`. This includes position, velocity,
+attitude, gyro-bias, and accelerometer-bias cross-couplings from one consistent model.
+Enable it together with continuous process noise for new profiles; existing profiles
+retain the hand-discretized legacy transition by default.
+
+`use_second_order_process_noise` integrates continuous error-state noise through the
+transition dynamics up to third order in `dt`. This generates position–velocity and
+other cross-covariance terms within each IMU step. Enable it together with continuous
+process noise and the second-order state transition.
+| `use_nonholonomic_constraint` | bool | false | Constrain body lateral and vertical velocity |
+| `var_nhc_lateral_velocity` | double | 0.05 | Lateral pseudo-measurement variance `[(m/s)^2]` |
+| `var_nhc_vertical_velocity` | double | 0.02 | Vertical pseudo-measurement variance `[(m/s)^2]` |
+| `min_nhc_forward_speed_mps` | double | 0.5 | Minimum absolute forward speed for NHC `[m/s]` |
+| `nhc_adaptive_yaw_rate_radps` | double | 0.5 | Yaw-rate scale where NHC covariance starts increasing |
+| `nhc_adaptive_lateral_accel_mps2` | double | 1.5 | Lateral-acceleration scale for adaptive covariance |
+| `max_nhc_variance_scale` | double | 100.0 | Maximum adaptive NHC covariance multiplier |
+| `use_zupt` | bool | false | Apply zero-velocity updates after stationary detection |
+| `zupt_max_angular_velocity_radps` | double | 0.02 | Maximum gyro norm for stationary detection `[rad/s]` |
+| `zupt_max_acceleration_error_mps2` | double | 0.2 | Maximum acceleration-norm error from gravity `[m/s^2]` |
+| `zupt_max_speed_mps` | double | 0.3 | Maximum estimated speed for stationary detection `[m/s]` |
+| `zupt_min_stationary_duration_sec` | double | 0.5 | Required continuous stationary duration `[s]` |
+| `var_zupt_velocity` | double | 0.01 | Zero-velocity observation variance `[(m/s)^2]` |
+| `use_zihr` | bool | false | Estimate gyro bias from stationary angular-rate observations |
+| `var_zihr_gyro` | double | 1.0e-5 | Stationary gyro observation variance `[(rad/s)^2]` |
+
+The non-holonomic constraint assumes a wheeled vehicle whose body-frame lateral and
+vertical velocities are normally close to zero. Its covariance is weakened during
+high yaw-rate or lateral-acceleration motion. Keep it disabled for holonomic, airborne,
+marine, or intentionally sliding platforms.
+
+ZUPT additionally constrains all three velocity axes to zero after the IMU and estimated
+speed remain stationary for the configured duration. Because constant-speed motion can
+look stationary to an IMU, `zupt_max_speed_mps` is an essential second condition. Keep
+ZUPT disabled when no reliable low-speed estimate is available.
+
+ZIHR uses the same stationary detector but treats measured angular velocity as gyro
+bias while the platform is stopped. It can be enabled independently of ZUPT and is
+most useful when `initial_imu_gyro_bias_covariance` is nonzero so the bias state is
+allowed to converge.
 | `use_gnss_doppler_velocity` | bool | false | Fuse receiver-provided ENU Doppler velocity |
 | `gnss_doppler_velocity_topic` | string | `/ekf_localization_node/gnss/velocity` | Doppler velocity input topic |
 | `use_gnss_doppler_velocity_covariance` | bool | true | Use the message linear-velocity covariance when valid |
@@ -57,6 +126,24 @@ gnss_navsatfix_topic: "/gnss/fix"
 ```
 
 The node converts WGS84 latitude/longitude/altitude to local ENU `PoseStamped` internally and fuses it with the same GNSS variance parameters. By default, the first valid fix becomes the ENU origin, so `/initial_pose` should use the same local frame. To use a fixed origin, set `gnss_navsatfix_use_first_fix_as_origin: false` and provide `gnss_navsatfix_origin_latitude`, `gnss_navsatfix_origin_longitude`, and `gnss_navsatfix_origin_altitude`.
+
+When enabled, NavSatFix covariance entries 0, 4, and 8 are used as ENU X/Y/Z
+measurement variances. Unknown, non-finite, or non-positive covariance falls back to
+the configured fixed GNSS variance. Floors prevent overconfident receiver output and
+ceilings prevent a single message from effectively disabling correction.
+
+The GNSS lever arm is expressed in `robot_frame_id`: X forward, Y left, and Z up.
+The current estimated orientation rotates this offset into the reference frame before
+the antenna observation is evaluated. The EKF measurement Jacobian includes the
+lever-arm sensitivity to attitude error, allowing antenna position during turns to
+correct both body position and attitude. Leaving all three values at zero preserves
+the original position-only observation model.
+
+Optional GNSS delay compensation extrapolates the lever-arm-corrected position with the
+current estimated velocity. A positive `gnss_time_offset_sec` means the effective GNSS
+measurement time is later than its message timestamp. This constant-velocity model is
+intended for known, short receiver delays; it is not equivalent to state rewind and IMU
+replay during aggressive acceleration or turning.
 
 ## Evaluating localization accuracy
 
@@ -105,6 +192,68 @@ The repository includes a small deterministic CSV regression dataset under
 limits are tested on both supported ROS distributions by GitHub Actions. This dataset
 tests the evaluator; vehicle-specific rosbag baselines can use the same CLI and limits
 without committing large bag files to the repository.
+
+## Comparing ablation profiles
+
+Four starting profiles are provided: `research_baseline`, `research_nhc`,
+`research_robust`, and `research_full`. After producing one estimate CSV per profile,
+generate a comparison table with the first estimate treated as the baseline:
+
+```bash
+ros2 run kalman_filter_localization compare_localization_results \
+  --reference-csv ground_truth.csv \
+  --estimate baseline=baseline.csv \
+  --estimate nhc=nhc.csv \
+  --estimate robust=robust.csv \
+  --estimate full=full.csv \
+  --output-csv comparison.csv \
+  --output-markdown comparison.md
+```
+
+The research profiles are ablation starting points, not sensor-independent tuned
+defaults. Lever arm and delay parameters remain dataset/hardware-specific and must be
+configured separately.
+
+For UrbanNav Tokyo, the complete four-profile run can be reproduced with one command.
+The input bag must publish `/gnss_pose` and `/sensing/imu/imu_data`; the reference CSV
+uses the same columns described above.
+
+The official `UrbanNav-TK-20181219` archive provides `imu.csv`, `reference.csv`, rover
+and base RINEX files. One reproducible way to produce the GNSS solution and ROS 2 inputs
+is:
+
+```bash
+rnx2rtkp -p 2 -f 2 -t -s , -o odaiba_ublox_rtk.pos \
+  Odaiba/rover_ublox.obs Odaiba/base_trimble.obs Odaiba/base.nav
+
+ros2 run kalman_filter_localization prepare_urbannav_tokyo \
+  --imu-csv Odaiba/imu.csv \
+  --reference-csv Odaiba/reference.csv \
+  --rtklib-pos odaiba_ublox_rtk.pos \
+  --output-bag odaiba_input_bag \
+  --output-reference-csv odaiba_reference.csv
+```
+
+The converter expresses both trajectories in an ENU frame whose origin is the first
+Applanix reference position. It converts the dataset IMU from forward-right-down to
+ROS forward-left-up axes and repeats the initial reference pose before sensor playback
+so DDS discovery cannot lose initialization.
+
+```bash
+share="$(ros2 pkg prefix kalman_filter_localization)/share/kalman_filter_localization"
+ros2 run kalman_filter_localization run_urbannav_ablation \
+  --input-bag odaiba_input_bag \
+  --reference-csv odaiba_reference.csv \
+  --output-dir results/urbannav_tokyo \
+  --base-profile "$share/param/profiles/urbannav_tokyo_tuned.yaml" \
+  --profiles-dir "$share/param/profiles"
+```
+
+Each run stores its merged parameter YAML, process logs, recorded estimate bag, and
+`estimate.csv`. The top-level directory contains `manifest.json`, `comparison.csv`,
+and `comparison.md`. Use `--dry-run` to validate inputs and generate the exact configs
+and command manifest without starting ROS processes. Output directories must initially
+be absent or empty so previous results cannot be mixed into a new experiment.
 
 ## References
 

--- a/kalman_filter_localization_core/include/kalman_filter_localization/core/ekf_estimator.hpp
+++ b/kalman_filter_localization_core/include/kalman_filter_localization/core/ekf_estimator.hpp
@@ -35,6 +35,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include <algorithm>
 #include <cstdint>
 #include <cmath>
 
@@ -78,6 +79,34 @@ public:
     kInvalidVariance,
   };
 
+  enum class RobustLoss : std::uint8_t
+  {
+    kNone = 0,
+    kHuber,
+    kCauchy,
+  };
+
+  static double computeRobustVarianceScale(
+    const double normalized_residual,
+    const RobustLoss loss,
+    const double tuning_constant,
+    const double max_scale)
+  {
+    if (!std::isfinite(normalized_residual) || normalized_residual <= tuning_constant ||
+      !(tuning_constant > 0.0) || !(max_scale >= 1.0))
+    {
+      return 1.0;
+    }
+    double scale = 1.0;
+    if (loss == RobustLoss::kHuber) {
+      scale = normalized_residual / tuning_constant;
+    } else if (loss == RobustLoss::kCauchy) {
+      const double ratio = normalized_residual / tuning_constant;
+      scale = 1.0 + ratio * ratio;
+    }
+    return std::min(scale, max_scale);
+  }
+
   EKFEstimator()
   : previous_time_imu_(0.0),
     has_previous_time_imu_(false),
@@ -86,6 +115,9 @@ public:
     var_imu_acc_{0.33},
     var_imu_gyro_bias_{0.0},
     var_imu_acc_bias_{0.0},
+    use_continuous_process_noise_density_{false},
+    use_second_order_state_transition_{false},
+    use_second_order_process_noise_{false},
     max_prediction_dt_sec_{0.5},
     initial_gyro_bias_covariance_{0.0},
     initial_accel_bias_covariance_{0.0},
@@ -197,9 +229,7 @@ public:
     x_.segment(STATE::BGX, 3) = gyro_bias_decay * x_.segment(STATE::BGX, 3);
     x_.segment(STATE::BAX, 3) = accel_bias_decay * x_.segment(STATE::BAX, 3);
 
-    // F
-    EigenMatrixErrorState F = EigenMatrixErrorState::Identity();
-    F.block<3, 3>(0, 3) = dt_imu * Eigen::Matrix3d::Identity();
+    // Error-state transition matrix.
     Eigen::Matrix3d acc_skew;
     acc_skew <<
       0, -unbiased_acc(2), unbiased_acc(1),
@@ -210,24 +240,52 @@ public:
       0, -unbiased_gyro(2), unbiased_gyro(1),
       unbiased_gyro(2), 0, -unbiased_gyro(0),
       -unbiased_gyro(1), unbiased_gyro(0), 0;
-    F.block<3, 3>(ERROR_STATE::DX, ERROR_STATE::DTHX) =
-      0.5 * rot_mat * (-acc_skew) * dt_imu * dt_imu;
-    F.block<3, 3>(ERROR_STATE::DX, ERROR_STATE::DBAX) =
-      -0.5 * rot_mat * dt_imu * dt_imu;
-    F.block<3, 3>(ERROR_STATE::DVX, ERROR_STATE::DTHX) = rot_mat * (-acc_skew) * dt_imu;
-    F.block<3, 3>(ERROR_STATE::DVX, ERROR_STATE::DBAX) = -rot_mat * dt_imu;
-    F.block<3, 3>(ERROR_STATE::DTHX, ERROR_STATE::DTHX) =
-      Eigen::Matrix3d::Identity() - gyro_skew * dt_imu;
-    F.block<3, 3>(ERROR_STATE::DTHX, ERROR_STATE::DBGX) = -dt_imu * Eigen::Matrix3d::Identity();
-    F.block<3, 3>(ERROR_STATE::DBGX, ERROR_STATE::DBGX) =
-      gyro_bias_decay * Eigen::Matrix3d::Identity();
-    F.block<3, 3>(ERROR_STATE::DBAX, ERROR_STATE::DBAX) =
-      accel_bias_decay * Eigen::Matrix3d::Identity();
+    EigenMatrixErrorState F = EigenMatrixErrorState::Identity();
+    EigenMatrixErrorState Fc = EigenMatrixErrorState::Zero();
+    if (use_second_order_state_transition_) {
+      Fc.block<3, 3>(ERROR_STATE::DX, ERROR_STATE::DVX) = Eigen::Matrix3d::Identity();
+      Fc.block<3, 3>(ERROR_STATE::DVX, ERROR_STATE::DTHX) = rot_mat * (-acc_skew);
+      Fc.block<3, 3>(ERROR_STATE::DVX, ERROR_STATE::DBAX) = -rot_mat;
+      Fc.block<3, 3>(ERROR_STATE::DTHX, ERROR_STATE::DTHX) = -gyro_skew;
+      Fc.block<3, 3>(ERROR_STATE::DTHX, ERROR_STATE::DBGX) = -Eigen::Matrix3d::Identity();
+      if (tau_gyro_bias_ > 0.0 && std::isfinite(tau_gyro_bias_)) {
+        Fc.block<3, 3>(ERROR_STATE::DBGX, ERROR_STATE::DBGX) =
+          (-1.0 / tau_gyro_bias_) * Eigen::Matrix3d::Identity();
+      }
+      if (tau_acc_bias_ > 0.0 && std::isfinite(tau_acc_bias_)) {
+        Fc.block<3, 3>(ERROR_STATE::DBAX, ERROR_STATE::DBAX) =
+          (-1.0 / tau_acc_bias_) * Eigen::Matrix3d::Identity();
+      }
+      const EigenMatrixErrorState Fc_dt = Fc * dt_imu;
+      F += Fc_dt + 0.5 * Fc_dt * Fc_dt;
+    } else {
+      F.block<3, 3>(ERROR_STATE::DX, ERROR_STATE::DVX) =
+        dt_imu * Eigen::Matrix3d::Identity();
+      F.block<3, 3>(ERROR_STATE::DX, ERROR_STATE::DTHX) =
+        0.5 * rot_mat * (-acc_skew) * dt_imu * dt_imu;
+      F.block<3, 3>(ERROR_STATE::DX, ERROR_STATE::DBAX) =
+        -0.5 * rot_mat * dt_imu * dt_imu;
+      F.block<3, 3>(ERROR_STATE::DVX, ERROR_STATE::DTHX) =
+        rot_mat * (-acc_skew) * dt_imu;
+      F.block<3, 3>(ERROR_STATE::DVX, ERROR_STATE::DBAX) = -rot_mat * dt_imu;
+      F.block<3, 3>(ERROR_STATE::DTHX, ERROR_STATE::DTHX) =
+        Eigen::Matrix3d::Identity() - gyro_skew * dt_imu;
+      F.block<3, 3>(ERROR_STATE::DTHX, ERROR_STATE::DBGX) =
+        -dt_imu * Eigen::Matrix3d::Identity();
+      F.block<3, 3>(ERROR_STATE::DBGX, ERROR_STATE::DBGX) =
+        gyro_bias_decay * Eigen::Matrix3d::Identity();
+      F.block<3, 3>(ERROR_STATE::DBAX, ERROR_STATE::DBAX) =
+        accel_bias_decay * Eigen::Matrix3d::Identity();
+    }
 
     // Q
     Eigen::Matrix<double, 12, 12> Q = Eigen::Matrix<double, 12, 12>::Zero();
-    Q.block<3, 3>(0, 0) = var_imu_acc_ * Eigen::Matrix3d::Identity() * (dt_imu * dt_imu);
-    Q.block<3, 3>(3, 3) = var_imu_w_ * Eigen::Matrix3d::Identity() * (dt_imu * dt_imu);
+    const double imu_white_noise_scale =
+      use_continuous_process_noise_density_ ? dt_imu : dt_imu * dt_imu;
+    Q.block<3, 3>(0, 0) =
+      var_imu_acc_ * Eigen::Matrix3d::Identity() * imu_white_noise_scale;
+    Q.block<3, 3>(3, 3) =
+      var_imu_w_ * Eigen::Matrix3d::Identity() * imu_white_noise_scale;
     Q.block<3, 3>(6, 6) = var_imu_gyro_bias_ * Eigen::Matrix3d::Identity() * dt_imu;
     Q.block<3, 3>(9, 9) = var_imu_acc_bias_ * Eigen::Matrix3d::Identity() * dt_imu;
 
@@ -241,7 +299,26 @@ public:
     L.block<3, 3>(ERROR_STATE::DBGX, 6) = Eigen::Matrix3d::Identity();
     L.block<3, 3>(ERROR_STATE::DBAX, 9) = Eigen::Matrix3d::Identity();
 
-    P_ = F * P_ * F.transpose() + L * Q * L.transpose();
+    EigenMatrixErrorState discrete_process_noise;
+    if (use_continuous_process_noise_density_ && use_second_order_process_noise_) {
+      Eigen::Matrix<double, 12, 12> Qc = Eigen::Matrix<double, 12, 12>::Zero();
+      Qc.block<3, 3>(0, 0) = var_imu_acc_ * Eigen::Matrix3d::Identity();
+      Qc.block<3, 3>(3, 3) = var_imu_w_ * Eigen::Matrix3d::Identity();
+      Qc.block<3, 3>(6, 6) = var_imu_gyro_bias_ * Eigen::Matrix3d::Identity();
+      Qc.block<3, 3>(9, 9) = var_imu_acc_bias_ * Eigen::Matrix3d::Identity();
+      const EigenMatrixErrorState Qe = L * Qc * L.transpose();
+      const EigenMatrixErrorState Fc2 = Fc * Fc;
+      const double dt2 = dt_imu * dt_imu;
+      const double dt3 = dt2 * dt_imu;
+      discrete_process_noise =
+        Qe * dt_imu +
+        0.5 * (Fc * Qe + Qe * Fc.transpose()) * dt2 +
+        (Fc2 * Qe + 2.0 * Fc * Qe * Fc.transpose() +
+        Qe * Fc.transpose() * Fc.transpose()) * (dt3 / 6.0);
+    } else {
+      discrete_process_noise = L * Q * L.transpose();
+    }
+    P_ = F * P_ * F.transpose() + discrete_process_noise;
     P_ = 0.5 * (P_ + P_.transpose());
     return PredictionUpdateStatus::kUpdated;
   }
@@ -371,6 +448,74 @@ public:
     return ObservationUpdateStatus::kUpdated;
   }
 
+  ObservationUpdateStatus observationUpdatePositionWithLeverArmWithStatus(
+    const Eigen::Vector3d & antenna_position_world,
+    const Eigen::Vector3d & antenna_lever_arm_body,
+    const Eigen::Vector3d & variance)
+  {
+    if (!antenna_position_world.allFinite() || !antenna_lever_arm_body.allFinite()) {
+      return ObservationUpdateStatus::kInvalidMeasurement;
+    }
+    if (!variance.allFinite() || (variance.array() <= 0.0).any()) {
+      return ObservationUpdateStatus::kInvalidVariance;
+    }
+    Eigen::Quaterniond orientation(
+      x_(STATE::QW), x_(STATE::QX), x_(STATE::QY), x_(STATE::QZ));
+    orientation.normalize();
+    const Eigen::Matrix3d world_from_body = orientation.toRotationMatrix();
+    const Eigen::Vector3d predicted_antenna =
+      x_.segment(STATE::X, 3) + world_from_body * antenna_lever_arm_body;
+    Eigen::Matrix3d lever_arm_skew;
+    lever_arm_skew <<
+      0.0, -antenna_lever_arm_body.z(), antenna_lever_arm_body.y(),
+      antenna_lever_arm_body.z(), 0.0, -antenna_lever_arm_body.x(),
+      -antenna_lever_arm_body.y(), antenna_lever_arm_body.x(), 0.0;
+
+    Eigen::Matrix<double, 3, num_error_state_> H =
+      Eigen::Matrix<double, 3, num_error_state_>::Zero();
+    H.block<3, 3>(0, ERROR_STATE::DX) = Eigen::Matrix3d::Identity();
+    H.block<3, 3>(0, ERROR_STATE::DTHX) = -world_from_body * lever_arm_skew;
+    const Eigen::Matrix3d R = variance.asDiagonal();
+    const Eigen::Matrix3d S = H * P_ * H.transpose() + R;
+    const Eigen::Matrix<double, num_error_state_, 3> K =
+      P_ * H.transpose() * S.inverse();
+    const Eigen::Matrix<double, num_error_state_, 1> dx =
+      K * (antenna_position_world - predicted_antenna);
+    applyErrorState(dx);
+    const EigenMatrixErrorState I = EigenMatrixErrorState::Identity();
+    const EigenMatrixErrorState A = I - K * H;
+    P_ = A * P_ * A.transpose() + K * R * K.transpose();
+    P_ = 0.5 * (P_ + P_.transpose());
+    return ObservationUpdateStatus::kUpdated;
+  }
+
+  ObservationUpdateStatus observationUpdateGyroBiasWithStatus(
+    const Eigen::Vector3d & measured_stationary_gyro,
+    const Eigen::Vector3d & variance)
+  {
+    if (!measured_stationary_gyro.allFinite()) {
+      return ObservationUpdateStatus::kInvalidMeasurement;
+    }
+    if (!variance.allFinite() || (variance.array() <= 0.0).any()) {
+      return ObservationUpdateStatus::kInvalidVariance;
+    }
+    Eigen::Matrix<double, 3, num_error_state_> H =
+      Eigen::Matrix<double, 3, num_error_state_>::Zero();
+    H.block<3, 3>(0, ERROR_STATE::DBGX) = Eigen::Matrix3d::Identity();
+    const Eigen::Matrix3d R = variance.asDiagonal();
+    const Eigen::Matrix3d S = H * P_ * H.transpose() + R;
+    const Eigen::Matrix<double, num_error_state_, 3> K =
+      P_ * H.transpose() * S.inverse();
+    const Eigen::Matrix<double, num_error_state_, 1> dx =
+      K * (measured_stationary_gyro - x_.segment(STATE::BGX, 3));
+    applyErrorState(dx);
+    const EigenMatrixErrorState I = EigenMatrixErrorState::Identity();
+    const EigenMatrixErrorState A = I - K * H;
+    P_ = A * P_ * A.transpose() + K * R * K.transpose();
+    P_ = 0.5 * (P_ + P_.transpose());
+    return ObservationUpdateStatus::kUpdated;
+  }
+
   void observationUpdateVelocity(
     const Eigen::Vector3d & y,
     const Eigen::Vector3d & variance
@@ -415,6 +560,52 @@ public:
 
     applyErrorState(dx);
 
+    const EigenMatrixErrorState I = EigenMatrixErrorState::Identity();
+    const EigenMatrixErrorState A = I - K * H;
+    P_ = A * P_ * A.transpose() + K * R * K.transpose();
+    P_ = 0.5 * (P_ + P_.transpose());
+    return ObservationUpdateStatus::kUpdated;
+  }
+
+  // Constrain lateral and vertical velocity expressed in the body frame.
+  // For right-multiplicative attitude error, h = R^T v has Jacobians
+  // dh / d(dtheta) = skew(h) and dh / d(dv) = R^T.
+  ObservationUpdateStatus observationUpdateBodyVelocityConstraintWithStatus(
+    const Eigen::Vector2d & lateral_vertical_velocity,
+    const Eigen::Vector2d & variance)
+  {
+    if (!lateral_vertical_velocity.allFinite()) {
+      return ObservationUpdateStatus::kInvalidMeasurement;
+    }
+    if (!variance.allFinite() || (variance.array() <= 0.0).any()) {
+      return ObservationUpdateStatus::kInvalidVariance;
+    }
+
+    Eigen::Quaterniond orientation(
+      x_(STATE::QW), x_(STATE::QX), x_(STATE::QY), x_(STATE::QZ));
+    orientation.normalize();
+    const Eigen::Matrix3d body_from_world = orientation.toRotationMatrix().transpose();
+    const Eigen::Vector3d body_velocity = body_from_world * x_.segment(STATE::VX, 3);
+
+    Eigen::Matrix<double, 2, num_error_state_> H =
+      Eigen::Matrix<double, 2, num_error_state_>::Zero();
+    Eigen::Matrix3d body_velocity_skew;
+    body_velocity_skew <<
+      0.0, -body_velocity.z(), body_velocity.y(),
+      body_velocity.z(), 0.0, -body_velocity.x(),
+      -body_velocity.y(), body_velocity.x(), 0.0;
+    H.block<2, 3>(0, ERROR_STATE::DVX) = body_from_world.block<2, 3>(1, 0);
+    H.block<2, 3>(0, ERROR_STATE::DTHX) = body_velocity_skew.block<2, 3>(1, 0);
+
+    const Eigen::Matrix2d R = variance.asDiagonal();
+    const Eigen::Matrix2d S = H * P_ * H.transpose() + R;
+    const Eigen::Matrix<double, num_error_state_, 2> K =
+      P_ * H.transpose() * S.inverse();
+    const Eigen::Vector2d predicted = body_velocity.tail<2>();
+    const Eigen::Matrix<double, num_error_state_, 1> dx =
+      K * (lateral_vertical_velocity - predicted);
+
+    applyErrorState(dx);
     const EigenMatrixErrorState I = EigenMatrixErrorState::Identity();
     const EigenMatrixErrorState A = I - K * H;
     P_ = A * P_ * A.transpose() + K * R * K.transpose();
@@ -470,6 +661,21 @@ public:
   void setVarImuAcc(const double var_imu_acc)
   {
     var_imu_acc_ = var_imu_acc;
+  }
+
+  void setUseContinuousProcessNoiseDensity(const bool enabled)
+  {
+    use_continuous_process_noise_density_ = enabled;
+  }
+
+  void setUseSecondOrderStateTransition(const bool enabled)
+  {
+    use_second_order_state_transition_ = enabled;
+  }
+
+  void setUseSecondOrderProcessNoise(const bool enabled)
+  {
+    use_second_order_process_noise_ = enabled;
   }
 
   bool setMaxPredictionDtSec(const double max_prediction_dt_sec)
@@ -720,6 +926,9 @@ private:
   double var_imu_acc_;
   double var_imu_gyro_bias_;
   double var_imu_acc_bias_;
+  bool use_continuous_process_noise_density_;
+  bool use_second_order_state_transition_;
+  bool use_second_order_process_noise_;
   double max_prediction_dt_sec_;
   double initial_gyro_bias_covariance_;
   double initial_accel_bias_covariance_;

--- a/kalman_filter_localization_core/include/kalman_filter_localization/core/odometry.hpp
+++ b/kalman_filter_localization_core/include/kalman_filter_localization/core/odometry.hpp
@@ -33,6 +33,10 @@
 #define KALMAN_FILTER_LOCALIZATION__CORE__ODOMETRY_HPP_
 
 #include <Eigen/Core>
+#include <Eigen/Geometry>
+
+#include <algorithm>
+#include <cmath>
 
 namespace kalman_filter_localization
 {
@@ -45,6 +49,59 @@ inline Eigen::Matrix4d composePoseWithRelativeOdom(
   const Eigen::Matrix4d & current_odom_pose)
 {
   return previous_global_pose * previous_odom_pose.inverse() * current_odom_pose;
+}
+
+// Convert a GNSS antenna position into the body/IMU origin position.
+inline Eigen::Vector3d removeLeverArmFromPosition(
+  const Eigen::Vector3d & antenna_position_world,
+  const Eigen::Quaterniond & world_from_body,
+  const Eigen::Vector3d & antenna_lever_arm_body)
+{
+  return antenna_position_world -
+         world_from_body.normalized() * antenna_lever_arm_body;
+}
+
+inline bool isStationaryImu(
+  const Eigen::Vector3d & angular_velocity,
+  const Eigen::Vector3d & linear_acceleration,
+  const double estimated_speed,
+  const double gravity_mps2,
+  const double max_angular_velocity,
+  const double max_acceleration_error,
+  const double max_speed)
+{
+  return angular_velocity.allFinite() && linear_acceleration.allFinite() &&
+         std::isfinite(estimated_speed) &&
+         angular_velocity.norm() <= max_angular_velocity &&
+         std::fabs(linear_acceleration.norm() - gravity_mps2) <= max_acceleration_error &&
+         estimated_speed <= max_speed;
+}
+
+inline Eigen::Vector3d extrapolatePositionConstantVelocity(
+  const Eigen::Vector3d & position,
+  const Eigen::Vector3d & velocity,
+  const double duration_sec)
+{
+  return position + velocity * duration_sec;
+}
+
+inline Eigen::Vector3d sanitizeMeasurementVariance(
+  const Eigen::Vector3d & candidate,
+  const Eigen::Vector3d & fallback,
+  const Eigen::Vector3d & minimum,
+  const Eigen::Vector3d & maximum)
+{
+  Eigen::Vector3d result;
+  for (int index = 0; index < 3; ++index) {
+    result(index) =
+      std::isfinite(candidate(index)) && candidate(index) > 0.0 ?
+      candidate(index) : fallback(index);
+    result(index) = std::max(result(index), minimum(index));
+    if (maximum(index) > 0.0) {
+      result(index) = std::min(result(index), maximum(index));
+    }
+  }
+  return result;
 }
 }  // namespace core
 }  // namespace kalman_filter_localization

--- a/kalman_filter_localization_core/test/test_ekf_core.cpp
+++ b/kalman_filter_localization_core/test/test_ekf_core.cpp
@@ -130,6 +130,41 @@ TEST(EKFEstimatorCore, ObservationUpdateVelocityKeepsOrientationWhenDecoupled)
   EXPECT_LT(angle_err, 1e-10);
 }
 
+TEST(EKFEstimatorCore, BodyVelocityConstraintReducesLateralAndVerticalVelocity)
+{
+  EKFEstimator ekf;
+  EKFEstimator::State state;
+  state.velocity = Eigen::Vector3d(5.0, 1.0, -0.5);
+  ekf.setState(state);
+
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_EQ(
+      ekf.observationUpdateBodyVelocityConstraintWithStatus(
+        Eigen::Vector2d::Zero(), Eigen::Vector2d(0.01, 0.01)),
+      EKFEstimator::ObservationUpdateStatus::kUpdated);
+  }
+
+  const Eigen::Vector3d body_velocity =
+    ekf.getOrientation().toRotationMatrix().transpose() * ekf.getVelocity();
+  EXPECT_NEAR(body_velocity.y(), 0.0, 1.0e-3);
+  EXPECT_NEAR(body_velocity.z(), 0.0, 1.0e-3);
+  EXPECT_GT(body_velocity.x(), 4.9);
+}
+
+TEST(EKFEstimatorCore, BodyVelocityConstraintValidatesInputs)
+{
+  EKFEstimator ekf;
+  EXPECT_EQ(
+    ekf.observationUpdateBodyVelocityConstraintWithStatus(
+      Eigen::Vector2d::Zero(), Eigen::Vector2d(0.0, 0.1)),
+    EKFEstimator::ObservationUpdateStatus::kInvalidVariance);
+  EXPECT_EQ(
+    ekf.observationUpdateBodyVelocityConstraintWithStatus(
+      Eigen::Vector2d(std::numeric_limits<double>::quiet_NaN(), 0.0),
+      Eigen::Vector2d(0.1, 0.1)),
+    EKFEstimator::ObservationUpdateStatus::kInvalidMeasurement);
+}
+
 TEST(EKFEstimatorCore, PredictionUpdateSubtractsGyroBias)
 {
   EKFEstimator ekf;
@@ -429,4 +464,154 @@ TEST(EKFEstimatorCore, MaxPredictionDtSecConfig)
   EXPECT_EQ(
     ekf.predictionUpdateDt(1.0, gyro, acc),
     EKFEstimator::PredictionUpdateStatus::kUpdated);
+}
+
+TEST(EKFEstimatorCore, ContinuousNoiseDensityIsImuRateIndependent)
+{
+  EKFEstimator ekf_100_hz;
+  EKFEstimator ekf_200_hz;
+  ekf_100_hz.setUseContinuousProcessNoiseDensity(true);
+  ekf_200_hz.setUseContinuousProcessNoiseDensity(true);
+  ekf_100_hz.setVarImuAcc(0.4);
+  ekf_200_hz.setVarImuAcc(0.4);
+  ekf_100_hz.setVarImuGyro(0.2);
+  ekf_200_hz.setVarImuGyro(0.2);
+
+  const Eigen::Vector3d gyro = Eigen::Vector3d::Zero();
+  const Eigen::Vector3d acceleration = Eigen::Vector3d::Zero();
+  for (int i = 0; i < 100; ++i) {
+    EXPECT_EQ(
+      ekf_100_hz.predictionUpdateDt(0.01, gyro, acceleration),
+      EKFEstimator::PredictionUpdateStatus::kUpdated);
+  }
+  for (int i = 0; i < 200; ++i) {
+    EXPECT_EQ(
+      ekf_200_hz.predictionUpdateDt(0.005, gyro, acceleration),
+      EKFEstimator::PredictionUpdateStatus::kUpdated);
+  }
+
+  const Eigen::MatrixXd covariance_100_hz = ekf_100_hz.getCovariance();
+  const Eigen::MatrixXd covariance_200_hz = ekf_200_hz.getCovariance();
+  const Eigen::Matrix3d velocity_covariance_100_hz = covariance_100_hz.block<3, 3>(3, 3);
+  const Eigen::Matrix3d velocity_covariance_200_hz = covariance_200_hz.block<3, 3>(3, 3);
+  const Eigen::Matrix3d attitude_covariance_100_hz = covariance_100_hz.block<3, 3>(6, 6);
+  const Eigen::Matrix3d attitude_covariance_200_hz = covariance_200_hz.block<3, 3>(6, 6);
+  EXPECT_TRUE(velocity_covariance_100_hz.isApprox(velocity_covariance_200_hz, 1.0e-9));
+  EXPECT_TRUE(attitude_covariance_100_hz.isApprox(attitude_covariance_200_hz, 1.0e-9));
+}
+
+TEST(EKFEstimatorCore, SecondOrderTransitionReducesImuRateSensitivity)
+{
+  EKFEstimator ekf_100_hz;
+  EKFEstimator ekf_200_hz;
+  ekf_100_hz.setUseContinuousProcessNoiseDensity(true);
+  ekf_200_hz.setUseContinuousProcessNoiseDensity(true);
+  ekf_100_hz.setUseSecondOrderStateTransition(true);
+  ekf_200_hz.setUseSecondOrderStateTransition(true);
+  const Eigen::Vector3d gyro(0.02, -0.01, 0.1);
+  const Eigen::Vector3d acceleration(0.3, -0.2, 9.80665);
+
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_EQ(
+      ekf_100_hz.predictionUpdateDt(0.01, gyro, acceleration),
+      EKFEstimator::PredictionUpdateStatus::kUpdated);
+  }
+  for (int i = 0; i < 200; ++i) {
+    ASSERT_EQ(
+      ekf_200_hz.predictionUpdateDt(0.005, gyro, acceleration),
+      EKFEstimator::PredictionUpdateStatus::kUpdated);
+  }
+
+  const Eigen::MatrixXd covariance_100_hz = ekf_100_hz.getCovariance();
+  const Eigen::MatrixXd covariance_200_hz = ekf_200_hz.getCovariance();
+  const double relative_difference =
+    (covariance_100_hz - covariance_200_hz).norm() / covariance_200_hz.norm();
+  EXPECT_LT(relative_difference, 2.0e-3);
+}
+
+TEST(EKFEstimatorCore, RobustLossContinuouslyInflatesMeasurementVariance)
+{
+  using RobustLoss = EKFEstimator::RobustLoss;
+  EXPECT_DOUBLE_EQ(
+    EKFEstimator::computeRobustVarianceScale(2.0, RobustLoss::kHuber, 2.5, 100.0), 1.0);
+  EXPECT_DOUBLE_EQ(
+    EKFEstimator::computeRobustVarianceScale(5.0, RobustLoss::kHuber, 2.5, 100.0), 2.0);
+  EXPECT_DOUBLE_EQ(
+    EKFEstimator::computeRobustVarianceScale(5.0, RobustLoss::kCauchy, 2.5, 100.0), 5.0);
+  EXPECT_DOUBLE_EQ(
+    EKFEstimator::computeRobustVarianceScale(1000.0, RobustLoss::kCauchy, 2.5, 20.0), 20.0);
+  EXPECT_DOUBLE_EQ(
+    EKFEstimator::computeRobustVarianceScale(5.0, RobustLoss::kNone, 2.5, 100.0), 1.0);
+}
+
+TEST(EKFEstimatorCore, LeverArmPositionUpdateReducesAntennaResidual)
+{
+  EKFEstimator ekf;
+  EKFEstimator::State state;
+  state.orientation = Eigen::Quaterniond(
+    Eigen::AngleAxisd(0.2, Eigen::Vector3d::UnitZ()));
+  ekf.setState(state);
+  const Eigen::Vector3d lever_arm(2.0, 0.0, 0.5);
+  const Eigen::Vector3d antenna_measurement = lever_arm;
+  const auto antenna_prediction = [&ekf, &lever_arm]() -> Eigen::Vector3d {
+      const Eigen::Vector3d position = ekf.getPosition();
+      const Eigen::Vector3d rotated_lever_arm = ekf.getOrientation() * lever_arm;
+      return position + rotated_lever_arm;
+    };
+  const double error_before = (antenna_measurement - antenna_prediction()).norm();
+
+  EXPECT_EQ(
+    ekf.observationUpdatePositionWithLeverArmWithStatus(
+      antenna_measurement, lever_arm, Eigen::Vector3d::Constant(0.01)),
+    EKFEstimator::ObservationUpdateStatus::kUpdated);
+
+  const double error_after = (antenna_measurement - antenna_prediction()).norm();
+  EXPECT_LT(error_after, error_before);
+}
+
+TEST(EKFEstimatorCore, StationaryGyroObservationEstimatesGyroBias)
+{
+  EKFEstimator ekf;
+  ASSERT_TRUE(ekf.setInitialGyroBiasCovariance(1.0));
+  const Eigen::Vector3d stationary_gyro(0.01, -0.02, 0.03);
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(
+      ekf.observationUpdateGyroBiasWithStatus(
+        stationary_gyro, Eigen::Vector3d::Constant(1.0e-5)),
+      EKFEstimator::ObservationUpdateStatus::kUpdated);
+  }
+  EXPECT_TRUE(ekf.getGyroBias().isApprox(stationary_gyro, 1.0e-4));
+  EXPECT_EQ(
+    ekf.observationUpdateGyroBiasWithStatus(
+      stationary_gyro, Eigen::Vector3d::Zero()),
+    EKFEstimator::ObservationUpdateStatus::kInvalidVariance);
+}
+
+TEST(EKFEstimatorCore, CoupledProcessNoiseIsImuRateIndependentForPosition)
+{
+  EKFEstimator ekf_100_hz;
+  EKFEstimator ekf_200_hz;
+  for (EKFEstimator * ekf : {&ekf_100_hz, &ekf_200_hz}) {
+    ekf->setUseContinuousProcessNoiseDensity(true);
+    ekf->setUseSecondOrderStateTransition(true);
+    ekf->setUseSecondOrderProcessNoise(true);
+    ekf->setVarImuAcc(0.4);
+    ekf->setVarImuGyro(0.2);
+  }
+  const Eigen::Vector3d zero = Eigen::Vector3d::Zero();
+  for (int i = 0; i < 100; ++i) {
+    ASSERT_EQ(
+      ekf_100_hz.predictionUpdateDt(0.01, zero, zero),
+      EKFEstimator::PredictionUpdateStatus::kUpdated);
+  }
+  for (int i = 0; i < 200; ++i) {
+    ASSERT_EQ(
+      ekf_200_hz.predictionUpdateDt(0.005, zero, zero),
+      EKFEstimator::PredictionUpdateStatus::kUpdated);
+  }
+  const Eigen::Matrix3d position_covariance_100_hz =
+    ekf_100_hz.getCovariance().block<3, 3>(0, 0);
+  const Eigen::Matrix3d position_covariance_200_hz =
+    ekf_200_hz.getCovariance().block<3, 3>(0, 0);
+  EXPECT_TRUE(position_covariance_100_hz.isApprox(position_covariance_200_hz, 1.0e-9));
 }

--- a/kalman_filter_localization_core/test/test_odometry_core.cpp
+++ b/kalman_filter_localization_core/test/test_odometry_core.cpp
@@ -36,6 +36,7 @@
 #include <Eigen/Geometry>
 
 #include <cmath>
+#include <limits>
 
 #include <kalman_filter_localization/core/odometry.hpp>
 
@@ -80,4 +81,53 @@ TEST(OdometryCore, ComposePoseWithRelativeOdomAppliesGlobalRotation)
   EXPECT_NEAR(composed(0, 3), 10.0, 1e-9);
   EXPECT_NEAR(composed(1, 3), 4.0, 1e-9);
   EXPECT_NEAR(composed(2, 3), 0.0, 1e-9);
+}
+
+TEST(OdometryCore, RemoveLeverArmUsesBodyOrientation)
+{
+  const double pi = std::acos(-1.0);
+  const Eigen::Quaterniond world_from_body(
+    Eigen::AngleAxisd(pi / 2.0, Eigen::Vector3d::UnitZ()));
+  const Eigen::Vector3d body_position(10.0, 20.0, 2.0);
+  const Eigen::Vector3d lever_arm_body(2.0, 0.0, 1.0);
+  const Eigen::Vector3d antenna_position =
+    body_position + world_from_body * lever_arm_body;
+
+  const Eigen::Vector3d result =
+    kalman_filter_localization::core::removeLeverArmFromPosition(
+    antenna_position, world_from_body, lever_arm_body);
+
+  EXPECT_TRUE(result.isApprox(body_position, 1.0e-12));
+}
+
+TEST(OdometryCore, StationaryImuRequiresAllSignalsToBeQuiet)
+{
+  using kalman_filter_localization::core::isStationaryImu;
+  const Eigen::Vector3d quiet_gyro(0.001, -0.002, 0.003);
+  const Eigen::Vector3d gravity(0.01, -0.02, 9.80);
+  EXPECT_TRUE(isStationaryImu(quiet_gyro, gravity, 0.05, 9.80665, 0.02, 0.2, 0.3));
+  EXPECT_FALSE(isStationaryImu(
+    Eigen::Vector3d(0.0, 0.0, 0.1), gravity, 0.05, 9.80665, 0.02, 0.2, 0.3));
+  EXPECT_FALSE(isStationaryImu(
+    quiet_gyro, Eigen::Vector3d(3.0, 0.0, 9.8), 0.05, 9.80665, 0.02, 0.2, 0.3));
+  EXPECT_FALSE(isStationaryImu(quiet_gyro, gravity, 2.0, 9.80665, 0.02, 0.2, 0.3));
+}
+
+TEST(OdometryCore, ExtrapolatePositionUsesConstantVelocity)
+{
+  const Eigen::Vector3d result =
+    kalman_filter_localization::core::extrapolatePositionConstantVelocity(
+    Eigen::Vector3d(1.0, 2.0, 3.0), Eigen::Vector3d(4.0, -2.0, 0.5), 0.25);
+  EXPECT_TRUE(result.isApprox(Eigen::Vector3d(2.0, 1.5, 3.125), 1.0e-12));
+}
+
+TEST(OdometryCore, SanitizeMeasurementVarianceFallsBackAndClamps)
+{
+  const Eigen::Vector3d result =
+    kalman_filter_localization::core::sanitizeMeasurementVariance(
+    Eigen::Vector3d(1.0e-6, std::numeric_limits<double>::quiet_NaN(), 100.0),
+    Eigen::Vector3d(0.1, 0.2, 0.3),
+    Eigen::Vector3d(0.01, 0.01, 0.02),
+    Eigen::Vector3d(10.0, 10.0, 5.0));
+  EXPECT_TRUE(result.isApprox(Eigen::Vector3d(0.01, 0.2, 5.0), 1.0e-12));
 }

--- a/kalman_filter_localization_ros2/CMakeLists.txt
+++ b/kalman_filter_localization_ros2/CMakeLists.txt
@@ -91,6 +91,24 @@ install(PROGRAMS
   RENAME evaluate_localization
 )
 
+install(PROGRAMS
+  scripts/compare_localization_results.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME compare_localization_results
+)
+
+install(PROGRAMS
+  scripts/run_urbannav_ablation.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME run_urbannav_ablation
+)
+
+install(PROGRAMS
+  scripts/prepare_urbannav_tokyo.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME prepare_urbannav_tokyo
+)
+
 install(TARGETS
   ekf_localization_node
   DESTINATION lib/kalman_filter_localization

--- a/kalman_filter_localization_ros2/launch/ekf.launch.py
+++ b/kalman_filter_localization_ros2/launch/ekf.launch.py
@@ -31,10 +31,9 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import os
 
+from ament_index_python.packages import get_package_share_directory
 import launch
 import launch_ros.actions
-
-from ament_index_python.packages import get_package_share_directory
 
 
 def generate_launch_description():

--- a/kalman_filter_localization_ros2/package.xml
+++ b/kalman_filter_localization_ros2/package.xml
@@ -10,6 +10,7 @@
   <exec_depend>rclpy</exec_depend>
   <exec_depend>rosbag2_py</exec_depend>
   <exec_depend>rosidl_runtime_py</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/kalman_filter_localization_ros2/param/ekf.yaml
+++ b/kalman_filter_localization_ros2/param/ekf.yaml
@@ -6,6 +6,17 @@ ekf_localization:
       gnss_input_type: "pose"  # "pose" or "navsatfix"
       gnss_navsatfix_topic: "/gnss/fix"
       gnss_navsatfix_use_first_fix_as_origin: true
+      gnss_navsatfix_use_position_covariance: false
+      gnss_navsatfix_min_variance_xy: 1.0e-4
+      gnss_navsatfix_min_variance_z: 1.0e-4
+      gnss_navsatfix_max_variance_xy: 100.0
+      gnss_navsatfix_max_variance_z: 100.0
+      gnss_lever_arm_x: 0.0
+      gnss_lever_arm_y: 0.0
+      gnss_lever_arm_z: 0.0
+      compensate_gnss_delay: false
+      gnss_time_offset_sec: 0.0
+      max_gnss_delay_compensation_sec: 0.5
       # gnss_navsatfix_origin_latitude: 35.0
       # gnss_navsatfix_origin_longitude: 139.0
       # gnss_navsatfix_origin_altitude: 0.0
@@ -16,6 +27,9 @@ ekf_localization:
       publish_tf: false
       var_imu_w: 0.01
       var_imu_acc: 0.01
+      use_continuous_process_noise_density: false
+      use_second_order_state_transition: false
+      use_second_order_process_noise: false
       var_imu_gyro_bias: 0.0
       initial_imu_gyro_bias_covariance: 0.0
       tau_gyro_bias_sec: 3600.0
@@ -27,6 +41,21 @@ ekf_localization:
       var_imu_orientation_rpy: 0.01
       use_flat_ground: false
       var_flat_ground_rp: 0.03
+      use_nonholonomic_constraint: false
+      var_nhc_lateral_velocity: 0.05
+      var_nhc_vertical_velocity: 0.02
+      min_nhc_forward_speed_mps: 0.5
+      nhc_adaptive_yaw_rate_radps: 0.5
+      nhc_adaptive_lateral_accel_mps2: 1.5
+      max_nhc_variance_scale: 100.0
+      use_zupt: false
+      zupt_max_angular_velocity_radps: 0.02
+      zupt_max_acceleration_error_mps2: 0.2
+      zupt_max_speed_mps: 0.3
+      zupt_min_stationary_duration_sec: 0.5
+      var_zupt_velocity: 0.01
+      use_zihr: false
+      var_zihr_gyro: 1.0e-5
       use_gnss_course_yaw: false
       var_gnss_course_yaw: 0.05
       min_gnss_course_distance_m: 1.0
@@ -52,6 +81,9 @@ ekf_localization:
       max_gnss_position_nis: 0.0  # 0 disables hard NIS gate
       gnss_position_nis_adaptive_threshold: 0.0  # 0 disables adaptive R
       max_gnss_position_variance_scale: 1.0
+      gnss_position_robust_loss: "none"  # "none", "huber", or "cauchy"
+      gnss_position_robust_tuning: 2.5
+      max_gnss_position_robust_variance_scale: 100.0
       gnss_position_reacquisition_dt_sec: 0.0  # 0 disables long-gap reacquisition R scaling
       gnss_position_reacquisition_variance_scale: 1.0
       gnss_position_reacquisition_update_count: 1

--- a/kalman_filter_localization_ros2/param/profiles/research_baseline.yaml
+++ b/kalman_filter_localization_ros2/param/profiles/research_baseline.yaml
@@ -1,0 +1,11 @@
+ekf_localization:
+  ros__parameters:
+    use_nonholonomic_constraint: false
+    use_zupt: false
+    use_zihr: false
+    compensate_gnss_delay: false
+    use_continuous_process_noise_density: false
+    use_second_order_state_transition: false
+    use_second_order_process_noise: false
+    gnss_position_robust_loss: "none"
+    gnss_navsatfix_use_position_covariance: false

--- a/kalman_filter_localization_ros2/param/profiles/research_full.yaml
+++ b/kalman_filter_localization_ros2/param/profiles/research_full.yaml
@@ -1,0 +1,17 @@
+ekf_localization:
+  ros__parameters:
+    use_nonholonomic_constraint: true
+    var_nhc_lateral_velocity: 0.05
+    var_nhc_vertical_velocity: 0.02
+    use_zupt: true
+    use_zihr: true
+    var_zupt_velocity: 0.01
+    var_zihr_gyro: 0.00001
+    initial_imu_gyro_bias_covariance: 0.01
+    use_continuous_process_noise_density: true
+    use_second_order_state_transition: true
+    use_second_order_process_noise: true
+    gnss_position_robust_loss: "huber"
+    gnss_position_robust_tuning: 2.5
+    max_gnss_position_robust_variance_scale: 100.0
+    gnss_navsatfix_use_position_covariance: true

--- a/kalman_filter_localization_ros2/param/profiles/research_nhc.yaml
+++ b/kalman_filter_localization_ros2/param/profiles/research_nhc.yaml
@@ -1,0 +1,9 @@
+ekf_localization:
+  ros__parameters:
+    use_nonholonomic_constraint: true
+    var_nhc_lateral_velocity: 0.05
+    var_nhc_vertical_velocity: 0.02
+    min_nhc_forward_speed_mps: 0.5
+    nhc_adaptive_yaw_rate_radps: 0.5
+    nhc_adaptive_lateral_accel_mps2: 1.5
+    max_nhc_variance_scale: 100.0

--- a/kalman_filter_localization_ros2/param/profiles/research_robust.yaml
+++ b/kalman_filter_localization_ros2/param/profiles/research_robust.yaml
@@ -1,0 +1,10 @@
+ekf_localization:
+  ros__parameters:
+    gnss_position_robust_loss: "huber"
+    gnss_position_robust_tuning: 2.5
+    max_gnss_position_robust_variance_scale: 100.0
+    gnss_navsatfix_use_position_covariance: true
+    gnss_navsatfix_min_variance_xy: 0.0001
+    gnss_navsatfix_min_variance_z: 0.0001
+    gnss_navsatfix_max_variance_xy: 100.0
+    gnss_navsatfix_max_variance_z: 100.0

--- a/kalman_filter_localization_ros2/scripts/compare_localization_results.py
+++ b/kalman_filter_localization_ros2/scripts/compare_localization_results.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, Ryohei Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD License 2.0)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#  * Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Compare localization result CSV files against one reference trajectory."""
+
+import argparse
+import csv
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec
+from importlib.util import spec_from_loader
+import math
+from pathlib import Path
+
+
+def load_evaluator():
+    """Load the evaluator from a source tree or an installed ROS executable."""
+    script_directory = Path(__file__).resolve().parent
+    source_path = script_directory / 'evaluate_localization.py'
+    installed_path = script_directory / 'evaluate_localization'
+    path = source_path if source_path.exists() else installed_path
+    loader = SourceFileLoader('evaluate_localization', str(path))
+    spec = spec_from_loader(loader.name, loader)
+    module = module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+EVALUATOR = load_evaluator()
+evaluate = EVALUATOR.evaluate
+read_csv = EVALUATOR.read_csv
+
+
+METRICS = [
+    'rmse_3d_m',
+    'rmse_horizontal_m',
+    'rmse_vertical_m',
+    'yaw_rmse_deg',
+    'max_error_3d_m',
+    'match_ratio',
+]
+
+
+def parse_estimate(value):
+    """Parse NAME=PATH command-line values."""
+    if '=' not in value:
+        raise argparse.ArgumentTypeError('estimate must use NAME=PATH')
+    name, path = value.split('=', 1)
+    if not name or not path:
+        raise argparse.ArgumentTypeError('estimate must use non-empty NAME=PATH')
+    return name, path
+
+
+def compare(reference_path, estimates, max_reference_gap, time_offset):
+    """Evaluate named trajectories and calculate deltas from the first result."""
+    references = read_csv(reference_path)
+    rows = []
+    for name, path in estimates:
+        summary, unused_errors = evaluate(
+            read_csv(path), references, max_reference_gap, time_offset)
+        row = {'name': name}
+        row.update({metric: summary[metric] for metric in METRICS})
+        rows.append(row)
+    if not rows:
+        raise ValueError('at least one estimate is required')
+    baseline = rows[0]
+    for row in rows:
+        for metric in METRICS:
+            baseline_value = baseline[metric]
+            value = row[metric]
+            row['delta_' + metric] = (
+                value - baseline_value
+                if value is not None and baseline_value is not None else None)
+    return rows
+
+
+def write_csv(path, rows):
+    """Write machine-readable comparison results."""
+    fields = ['name'] + METRICS + ['delta_' + metric for metric in METRICS]
+    with open(path, 'w', newline='', encoding='utf-8') as stream:
+        writer = csv.DictWriter(stream, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def format_value(value, digits=4):
+    """Format optional finite metric values for Markdown."""
+    return 'n/a' if value is None or not math.isfinite(value) else f'{value:.{digits}f}'
+
+
+def write_markdown(path, rows):
+    """Write a compact human-readable ablation table."""
+    lines = [
+        '| Profile | 3D RMSE m | Delta m | Horizontal m | Yaw RMSE deg | Max 3D m | Match |',
+        '|---|---:|---:|---:|---:|---:|---:|',
+    ]
+    for row in rows:
+        lines.append(
+            '| {} | {} | {} | {} | {} | {} | {} |'.format(
+                row['name'],
+                format_value(row['rmse_3d_m']),
+                format_value(row['delta_rmse_3d_m']),
+                format_value(row['rmse_horizontal_m']),
+                format_value(row['yaw_rmse_deg']),
+                format_value(row['max_error_3d_m']),
+                format_value(row['match_ratio'], 3)))
+    Path(path).write_text('\n'.join(lines) + '\n', encoding='utf-8')
+
+
+def main(argv=None):
+    """Run the comparison command."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--reference-csv', required=True)
+    parser.add_argument('--estimate', action='append', type=parse_estimate, required=True)
+    parser.add_argument('--max-reference-gap', type=float, default=0.2)
+    parser.add_argument('--time-offset', type=float, default=0.0)
+    parser.add_argument('--output-csv', required=True)
+    parser.add_argument('--output-markdown', required=True)
+    args = parser.parse_args(argv)
+    try:
+        rows = compare(
+            args.reference_csv, args.estimate, args.max_reference_gap, args.time_offset)
+        write_csv(args.output_csv, rows)
+        write_markdown(args.output_markdown, rows)
+        return 0
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/kalman_filter_localization_ros2/scripts/prepare_urbannav_tokyo.py
+++ b/kalman_filter_localization_ros2/scripts/prepare_urbannav_tokyo.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, Ryohei Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD License 2.0)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#  * Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Convert UrbanNav Tokyo CSV and RTKLIB output into ROS 2 evaluation inputs."""
+
+import argparse
+import csv
+from datetime import datetime
+import math
+from pathlib import Path
+import sys
+
+
+GPS_WEEK_SECONDS = 604800.0
+WGS84_A = 6378137.0
+WGS84_E2 = 6.69437999014e-3
+
+
+def normalize_fields(row):
+    """Strip the spaces present after commas in official UrbanNav CSV files."""
+    return {key.strip(): value.strip() for key, value in row.items()}
+
+
+def gps_stamp(week, tow):
+    """Return continuous GPS seconds suitable for consistent ROS timestamps."""
+    return float(week) * GPS_WEEK_SECONDS + float(tow)
+
+
+def geodetic_to_ecef(latitude_deg, longitude_deg, height):
+    """Convert WGS-84 geodetic coordinates to ECEF metres."""
+    latitude = math.radians(latitude_deg)
+    longitude = math.radians(longitude_deg)
+    sin_latitude = math.sin(latitude)
+    prime_vertical = WGS84_A / math.sqrt(1.0 - WGS84_E2 * sin_latitude ** 2)
+    return (
+        (prime_vertical + height) * math.cos(latitude) * math.cos(longitude),
+        (prime_vertical + height) * math.cos(latitude) * math.sin(longitude),
+        (prime_vertical * (1.0 - WGS84_E2) + height) * sin_latitude,
+    )
+
+
+def ecef_to_enu(ecef, origin_ecef, origin_latitude_deg, origin_longitude_deg):
+    """Rotate an ECEF displacement into local east, north, up coordinates."""
+    latitude = math.radians(origin_latitude_deg)
+    longitude = math.radians(origin_longitude_deg)
+    dx, dy, dz = (ecef[index] - origin_ecef[index] for index in range(3))
+    east = -math.sin(longitude) * dx + math.cos(longitude) * dy
+    north = (-math.sin(latitude) * math.cos(longitude) * dx -
+             math.sin(latitude) * math.sin(longitude) * dy +
+             math.cos(latitude) * dz)
+    up = (math.cos(latitude) * math.cos(longitude) * dx +
+          math.cos(latitude) * math.sin(longitude) * dy +
+          math.sin(latitude) * dz)
+    return east, north, up
+
+
+def read_reference(path):
+    """Read official Applanix reference CSV rows."""
+    rows = []
+    with open(path, newline='', encoding='utf-8-sig') as stream:
+        for raw in csv.DictReader(stream, skipinitialspace=True):
+            row = normalize_fields(raw)
+            rows.append({
+                'stamp': gps_stamp(row['GPS Week'], row['GPS TOW (s)']),
+                'latitude': float(row['Latitude (deg)']),
+                'longitude': float(row['Longitude (deg)']),
+                'height': float(row['Ellipsoid Height (m)']),
+                'heading': float(row['Heading (deg)']),
+            })
+    if not rows:
+        raise ValueError('reference CSV is empty')
+    return rows
+
+
+def write_reference(path, rows, origin):
+    """Write ground truth in the evaluator's local ENU CSV format."""
+    origin_ecef = geodetic_to_ecef(*origin)
+    with open(path, 'w', newline='', encoding='utf-8') as stream:
+        writer = csv.writer(stream)
+        writer.writerow(('stamp', 'x', 'y', 'z', 'yaw'))
+        for row in rows:
+            ecef = geodetic_to_ecef(
+                row['latitude'], row['longitude'], row['height'])
+            east, north, up = ecef_to_enu(ecef, origin_ecef, origin[0], origin[1])
+            yaw = math.atan2(
+                math.sin(math.radians(90.0 - row['heading'])),
+                math.cos(math.radians(90.0 - row['heading'])))
+            writer.writerow((row['stamp'], east, north, up, yaw))
+
+
+def read_rtk_position(path, week):
+    """Read comma-separated RTKLIB latitude/longitude/height solutions."""
+    rows = []
+    with open(path, encoding='utf-8') as stream:
+        for line in stream:
+            if not line.strip() or line.startswith('%'):
+                continue
+            fields = [field.strip() for field in line.split(',')]
+            timestamp = datetime.strptime(fields[0], '%Y/%m/%d %H:%M:%S.%f')
+            weekday_seconds = (
+                (timestamp.weekday() + 1) % 7 * 86400.0 +
+                timestamp.hour * 3600.0 + timestamp.minute * 60.0 +
+                timestamp.second + timestamp.microsecond * 1e-6)
+            rows.append({
+                'stamp': gps_stamp(week, weekday_seconds),
+                'latitude': float(fields[1]),
+                'longitude': float(fields[2]),
+                'height': float(fields[3]),
+            })
+    if not rows:
+        raise ValueError('RTKLIB position file is empty')
+    return rows
+
+
+def read_imu(path):
+    """Read official TAG264 IMU CSV and convert to ROS FLU body axes."""
+    rows = []
+    with open(path, newline='', encoding='utf-8-sig') as stream:
+        for raw in csv.DictReader(stream, skipinitialspace=True):
+            row = normalize_fields(raw)
+            rows.append({
+                'stamp': gps_stamp(row['GPS Week'], row['GPS TOW (s)']),
+                'acceleration': (
+                    float(row['Acceleration X (m/s^2)']),
+                    -float(row['Acceleration Y (m/s^2)']),
+                    -float(row['Acceleration Z (m/s^2)'])),
+                'angular_velocity': (
+                    float(row['Angular rate X (rad/s)']),
+                    -float(row['Angular rate Y (rad/s)']),
+                    -float(row['Angular rate Z (rad/s)'])),
+            })
+    if not rows:
+        raise ValueError('IMU CSV is empty')
+    return rows
+
+
+def to_ros_time(stamp):
+    """Convert floating-point seconds to a builtin_interfaces Time message."""
+    from builtin_interfaces.msg import Time
+    seconds = math.floor(stamp)
+    nanoseconds = round((stamp - seconds) * 1e9)
+    if nanoseconds == 1000000000:
+        seconds += 1
+        nanoseconds = 0
+    return Time(sec=seconds, nanosec=nanoseconds)
+
+
+def write_bag(path, imu_rows, position_rows, origin, initial_yaw):
+    """Write time-ordered IMU and local GNSS PoseStamped messages."""
+    import rosbag2_py
+    from geometry_msgs.msg import PoseStamped
+    from rclpy.serialization import serialize_message
+    from sensor_msgs.msg import Imu
+
+    writer = rosbag2_py.SequentialWriter()
+    writer.open(
+        rosbag2_py.StorageOptions(uri=str(path), storage_id='sqlite3'),
+        rosbag2_py.ConverterOptions('', ''))
+    writer.create_topic(rosbag2_py.TopicMetadata(
+        id=0, name='/sensing/imu/imu_data', type='sensor_msgs/msg/Imu',
+        serialization_format='cdr'))
+    writer.create_topic(rosbag2_py.TopicMetadata(
+        id=0, name='/gnss_pose', type='geometry_msgs/msg/PoseStamped',
+        serialization_format='cdr'))
+    writer.create_topic(rosbag2_py.TopicMetadata(
+        id=0, name='/ekf_localization/initial_pose',
+        type='geometry_msgs/msg/PoseStamped', serialization_format='cdr'))
+    origin_ecef = geodetic_to_ecef(*origin)
+    events = [(row['stamp'], 'imu', row) for row in imu_rows]
+    events.extend((row['stamp'], 'gnss', row) for row in position_rows)
+    first_stamp = min(imu_rows[0]['stamp'], position_rows[0]['stamp'])
+    # PoseStamped is volatile. Repeating initialization before sensor playback prevents
+    # a one-shot message from being lost while rosbag2 publishers discover subscribers.
+    events.extend(
+        (first_stamp - 2.0 + index * 0.1, 'initial', None)
+        for index in range(20))
+    for stamp, kind, row in sorted(events, key=lambda event: event[0]):
+        timestamp = to_ros_time(stamp)
+        if kind == 'imu':
+            message = Imu()
+            message.header.stamp = timestamp
+            message.header.frame_id = 'imu_link'
+            message.orientation_covariance[0] = -1.0
+            message.linear_acceleration.x, message.linear_acceleration.y, \
+                message.linear_acceleration.z = row['acceleration']
+            message.angular_velocity.x, message.angular_velocity.y, \
+                message.angular_velocity.z = row['angular_velocity']
+            topic = '/sensing/imu/imu_data'
+        elif kind == 'gnss':
+            message = PoseStamped()
+            message.header.stamp = timestamp
+            message.header.frame_id = 'map'
+            ecef = geodetic_to_ecef(
+                row['latitude'], row['longitude'], row['height'])
+            position = ecef_to_enu(
+                ecef, origin_ecef, origin[0], origin[1])
+            message.pose.position.x, message.pose.position.y, \
+                message.pose.position.z = position
+            message.pose.orientation.w = 1.0
+            topic = '/gnss_pose'
+        else:
+            message = PoseStamped()
+            message.header.stamp = timestamp
+            message.header.frame_id = 'map'
+            message.pose.orientation.z = math.sin(initial_yaw / 2.0)
+            message.pose.orientation.w = math.cos(initial_yaw / 2.0)
+            topic = '/ekf_localization/initial_pose'
+        writer.write(topic, serialize_message(message), round(stamp * 1e9))
+
+
+def main(argv=None):
+    """Prepare one official UrbanNav Tokyo sequence."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--imu-csv', type=Path, required=True)
+    parser.add_argument('--reference-csv', type=Path, required=True)
+    parser.add_argument('--rtklib-pos', type=Path, required=True)
+    parser.add_argument('--output-bag', type=Path, required=True)
+    parser.add_argument('--output-reference-csv', type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        for path in (args.imu_csv, args.reference_csv, args.rtklib_pos):
+            if not path.is_file():
+                raise ValueError('input file does not exist: {}'.format(path))
+        if args.output_bag.exists():
+            raise ValueError('output bag already exists: {}'.format(args.output_bag))
+        reference = read_reference(args.reference_csv)
+        origin = (
+            reference[0]['latitude'], reference[0]['longitude'],
+            reference[0]['height'])
+        week = math.floor(reference[0]['stamp'] / GPS_WEEK_SECONDS)
+        imu = read_imu(args.imu_csv)
+        positions = read_rtk_position(args.rtklib_pos, week)
+        args.output_bag.parent.mkdir(parents=True, exist_ok=True)
+        args.output_reference_csv.parent.mkdir(parents=True, exist_ok=True)
+        write_reference(args.output_reference_csv, reference, origin)
+        initial_yaw = math.radians(90.0 - reference[0]['heading'])
+        write_bag(args.output_bag, imu, positions, origin, initial_yaw)
+        print('wrote {} IMU and {} GNSS samples'.format(len(imu), len(positions)))
+        return 0
+    except (ImportError, OSError, ValueError) as error:
+        print('error: {}'.format(error), file=sys.stderr)
+        return 2
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/kalman_filter_localization_ros2/scripts/run_urbannav_ablation.py
+++ b/kalman_filter_localization_ros2/scripts/run_urbannav_ablation.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026, Ryohei Sasaki
+# All rights reserved.
+#
+# Software License Agreement (BSD License 2.0)
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#  * Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+"""Run reproducible UrbanNav Tokyo localization ablation experiments."""
+
+import argparse
+import csv
+from importlib.machinery import SourceFileLoader
+from importlib.util import module_from_spec
+from importlib.util import spec_from_loader
+import json
+import os
+from pathlib import Path
+import signal
+import subprocess
+import sys
+import time
+
+import yaml
+
+
+PROFILE_NAMES = ('baseline', 'nhc', 'robust', 'full')
+ESTIMATE_TOPIC = '/ekf_localization/current_pose'
+
+
+def deep_merge(base, override):
+    """Recursively merge dictionaries without modifying either input."""
+    result = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def load_yaml(path):
+    """Read one YAML mapping."""
+    with open(path, encoding='utf-8') as stream:
+        value = yaml.safe_load(stream)
+    if not isinstance(value, dict):
+        raise ValueError('{} does not contain a YAML mapping'.format(path))
+    return value
+
+
+def prepare_configs(base_profile, profiles_directory, output_directory):
+    """Write the exact merged parameter file used by every experiment."""
+    base = load_yaml(base_profile)
+    config_directory = output_directory / 'configs'
+    config_directory.mkdir(parents=True, exist_ok=True)
+    paths = {}
+    for name in PROFILE_NAMES:
+        override = load_yaml(profiles_directory / ('research_' + name + '.yaml'))
+        merged = deep_merge(base, override)
+        path = config_directory / (name + '.yaml')
+        path.write_text(yaml.safe_dump(merged, sort_keys=False), encoding='utf-8')
+        paths[name] = path
+    return paths
+
+
+def load_script_module(name):
+    """Load a sibling script in source and installed layouts."""
+    directory = Path(__file__).resolve().parent
+    source_path = directory / (name + '.py')
+    path = source_path if source_path.exists() else directory / name
+    loader = SourceFileLoader(name, str(path))
+    spec = spec_from_loader(loader.name, loader)
+    module = module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+def write_trajectory(path, samples):
+    """Write estimator samples in the common evaluation CSV format."""
+    with open(path, 'w', newline='', encoding='utf-8') as stream:
+        writer = csv.writer(stream)
+        writer.writerow(('stamp', 'x', 'y', 'z', 'yaw'))
+        for sample in samples:
+            writer.writerow((sample.stamp, sample.x, sample.y, sample.z, sample.yaw))
+
+
+def stop_process(process, timeout=10.0):
+    """Gracefully stop a subprocess group and force it down if necessary."""
+    if process.poll() is not None:
+        return
+    os.killpg(process.pid, signal.SIGINT)
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        os.killpg(process.pid, signal.SIGTERM)
+        process.wait(timeout=timeout)
+
+
+def start(command, log_path):
+    """Start a command in its own process group with a persistent log."""
+    log = open(log_path, 'w', encoding='utf-8')
+    process = subprocess.Popen(
+        command, stdout=log, stderr=subprocess.STDOUT,
+        start_new_session=True, text=True)
+    process.experiment_log = log
+    return process
+
+
+def run_profile(name, config, input_bag, output_directory, topic, rate, startup_delay):
+    """Replay one bag, record its estimate, and export that estimate to CSV."""
+    run_directory = output_directory / name
+    run_directory.mkdir()
+    estimate_bag = run_directory / 'estimate_bag'
+    launch_command = [
+        'ros2', 'launch', 'kalman_filter_localization', 'ekf.launch.py',
+        'ekf_param_dir:=' + str(config.resolve()),
+    ]
+    record_command = [
+        'ros2', 'bag', 'record', '--output', str(estimate_bag), topic,
+    ]
+    play_command = [
+        'ros2', 'bag', 'play', str(input_bag), '--rate', str(rate),
+        '--delay', str(startup_delay),
+    ]
+    launch = start(launch_command, run_directory / 'localization.log')
+    recorder = None
+    try:
+        time.sleep(startup_delay)
+        if launch.poll() is not None:
+            raise RuntimeError('{} localization exited before playback'.format(name))
+        recorder = start(record_command, run_directory / 'record.log')
+        time.sleep(startup_delay)
+        playback = subprocess.run(
+            play_command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, check=False)
+        (run_directory / 'playback.log').write_text(playback.stdout, encoding='utf-8')
+        if playback.returncode:
+            raise RuntimeError('{} bag playback failed'.format(name))
+        time.sleep(1.0)
+    finally:
+        if recorder is not None:
+            stop_process(recorder)
+            recorder.experiment_log.close()
+        stop_process(launch)
+        launch.experiment_log.close()
+    evaluator = load_script_module('evaluate_localization')
+    samples = evaluator.read_bag(str(estimate_bag), topic)
+    if not samples:
+        raise RuntimeError('{} produced no estimate samples'.format(name))
+    estimate_csv = run_directory / 'estimate.csv'
+    write_trajectory(estimate_csv, samples)
+    return estimate_csv, [launch_command, record_command, play_command]
+
+
+def command_manifest(
+        configs, input_bag, output_directory, topic, rate, startup_delay):
+    """Build a machine-readable dry-run manifest."""
+    runs = []
+    for name in PROFILE_NAMES:
+        run_directory = output_directory / name
+        runs.append({
+            'name': name,
+            'config': str(configs[name].resolve()),
+            'estimate_csv': str((run_directory / 'estimate.csv').resolve()),
+            'commands': [
+                ['ros2', 'launch', 'kalman_filter_localization', 'ekf.launch.py',
+                 'ekf_param_dir:=' + str(configs[name].resolve())],
+                ['ros2', 'bag', 'record', '--output',
+                 str(run_directory / 'estimate_bag'), topic],
+                ['ros2', 'bag', 'play', str(input_bag), '--rate', str(rate),
+                 '--delay', str(startup_delay)],
+            ],
+        })
+    return {'input_bag': str(input_bag), 'estimate_topic': topic, 'runs': runs}
+
+
+def main(argv=None):
+    """Run all UrbanNav ablations and produce comparison artifacts."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--input-bag', type=Path, required=True)
+    parser.add_argument('--reference-csv', type=Path, required=True)
+    parser.add_argument('--output-dir', type=Path, required=True)
+    parser.add_argument('--base-profile', type=Path, required=True)
+    parser.add_argument('--profiles-dir', type=Path, required=True)
+    parser.add_argument('--estimate-topic', default=ESTIMATE_TOPIC)
+    parser.add_argument('--rate', type=float, default=1.0)
+    parser.add_argument('--startup-delay', type=float, default=2.0)
+    parser.add_argument('--max-reference-gap', type=float, default=0.2)
+    parser.add_argument('--time-offset', type=float, default=0.0)
+    parser.add_argument('--dry-run', action='store_true')
+    args = parser.parse_args(argv)
+    try:
+        if args.output_dir.exists() and any(args.output_dir.iterdir()):
+            raise ValueError('output directory must be absent or empty')
+        if not args.input_bag.exists():
+            raise ValueError('input bag does not exist: {}'.format(args.input_bag))
+        if not args.reference_csv.is_file():
+            raise ValueError('reference CSV does not exist: {}'.format(args.reference_csv))
+        if args.rate <= 0.0 or args.startup_delay < 0.0:
+            raise ValueError('rate must be positive and startup delay non-negative')
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        configs = prepare_configs(
+            args.base_profile, args.profiles_dir, args.output_dir)
+        manifest = command_manifest(
+            configs, args.input_bag, args.output_dir, args.estimate_topic,
+            args.rate, args.startup_delay)
+        manifest_path = args.output_dir / 'manifest.json'
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2) + '\n', encoding='utf-8')
+        if args.dry_run:
+            print(manifest_path)
+            return 0
+        estimates = []
+        for name in PROFILE_NAMES:
+            estimate, unused_commands = run_profile(
+                name, configs[name], args.input_bag, args.output_dir,
+                args.estimate_topic, args.rate, args.startup_delay)
+            estimates.append((name, estimate))
+        comparator = load_script_module('compare_localization_results')
+        rows = comparator.compare(
+            args.reference_csv, estimates, args.max_reference_gap, args.time_offset)
+        comparator.write_csv(args.output_dir / 'comparison.csv', rows)
+        comparator.write_markdown(args.output_dir / 'comparison.md', rows)
+        print(args.output_dir / 'comparison.md')
+        return 0
+    except (OSError, RuntimeError, ValueError, yaml.YAMLError) as error:
+        print('error: {}'.format(error), file=sys.stderr)
+        return 2
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/kalman_filter_localization_ros2/src/ekf_localization_component.cpp
+++ b/kalman_filter_localization_ros2/src/ekf_localization_component.cpp
@@ -228,6 +228,17 @@ struct EkfLocalizationComponent::Impl
     node_.declare_parameter("gnss_navsatfix_use_first_fix_as_origin", true);
     node_.get_parameter(
       "gnss_navsatfix_use_first_fix_as_origin", gnss_navsatfix_use_first_fix_as_origin_);
+    node_.declare_parameter("gnss_navsatfix_use_position_covariance", false);
+    node_.get_parameter(
+      "gnss_navsatfix_use_position_covariance", gnss_navsatfix_use_position_covariance_);
+    node_.declare_parameter("gnss_navsatfix_min_variance_xy", 1.0e-4);
+    node_.get_parameter("gnss_navsatfix_min_variance_xy", gnss_navsatfix_min_variance_xy_);
+    node_.declare_parameter("gnss_navsatfix_min_variance_z", 1.0e-4);
+    node_.get_parameter("gnss_navsatfix_min_variance_z", gnss_navsatfix_min_variance_z_);
+    node_.declare_parameter("gnss_navsatfix_max_variance_xy", 100.0);
+    node_.get_parameter("gnss_navsatfix_max_variance_xy", gnss_navsatfix_max_variance_xy_);
+    node_.declare_parameter("gnss_navsatfix_max_variance_z", 100.0);
+    node_.get_parameter("gnss_navsatfix_max_variance_z", gnss_navsatfix_max_variance_z_);
     node_.declare_parameter(
       "gnss_navsatfix_origin_latitude", std::numeric_limits<double>::quiet_NaN());
     node_.get_parameter("gnss_navsatfix_origin_latitude", gnss_navsatfix_origin_latitude_);
@@ -237,6 +248,19 @@ struct EkfLocalizationComponent::Impl
     node_.declare_parameter(
       "gnss_navsatfix_origin_altitude", std::numeric_limits<double>::quiet_NaN());
     node_.get_parameter("gnss_navsatfix_origin_altitude", gnss_navsatfix_origin_altitude_);
+    node_.declare_parameter("gnss_lever_arm_x", 0.0);
+    node_.get_parameter("gnss_lever_arm_x", gnss_lever_arm_body_.x());
+    node_.declare_parameter("gnss_lever_arm_y", 0.0);
+    node_.get_parameter("gnss_lever_arm_y", gnss_lever_arm_body_.y());
+    node_.declare_parameter("gnss_lever_arm_z", 0.0);
+    node_.get_parameter("gnss_lever_arm_z", gnss_lever_arm_body_.z());
+    node_.declare_parameter("compensate_gnss_delay", false);
+    node_.get_parameter("compensate_gnss_delay", compensate_gnss_delay_);
+    node_.declare_parameter("gnss_time_offset_sec", 0.0);
+    node_.get_parameter("gnss_time_offset_sec", gnss_time_offset_sec_);
+    node_.declare_parameter("max_gnss_delay_compensation_sec", 0.5);
+    node_.get_parameter(
+      "max_gnss_delay_compensation_sec", max_gnss_delay_compensation_sec_);
 
     node_.declare_parameter("pub_period", 10);
     node_.get_parameter("pub_period", pub_period_);
@@ -244,6 +268,14 @@ struct EkfLocalizationComponent::Impl
     node_.get_parameter("var_imu_w", var_imu_w_);
     node_.declare_parameter("var_imu_acc", 0.01);
     node_.get_parameter("var_imu_acc", var_imu_acc_);
+    node_.declare_parameter("use_continuous_process_noise_density", false);
+    node_.get_parameter(
+      "use_continuous_process_noise_density", use_continuous_process_noise_density_);
+    node_.declare_parameter("use_second_order_state_transition", false);
+    node_.get_parameter(
+      "use_second_order_state_transition", use_second_order_state_transition_);
+    node_.declare_parameter("use_second_order_process_noise", false);
+    node_.get_parameter("use_second_order_process_noise", use_second_order_process_noise_);
     node_.declare_parameter("var_imu_gyro_bias", 0.0);
     node_.get_parameter("var_imu_gyro_bias", var_imu_gyro_bias_);
     node_.declare_parameter("initial_imu_gyro_bias_covariance", 0.0);
@@ -266,6 +298,37 @@ struct EkfLocalizationComponent::Impl
     node_.get_parameter("use_flat_ground", use_flat_ground_);
     node_.declare_parameter("var_flat_ground_rp", 0.03);
     node_.get_parameter("var_flat_ground_rp", var_flat_ground_rp_);
+    node_.declare_parameter("use_nonholonomic_constraint", false);
+    node_.get_parameter("use_nonholonomic_constraint", use_nonholonomic_constraint_);
+    node_.declare_parameter("var_nhc_lateral_velocity", 0.05);
+    node_.get_parameter("var_nhc_lateral_velocity", var_nhc_lateral_velocity_);
+    node_.declare_parameter("var_nhc_vertical_velocity", 0.02);
+    node_.get_parameter("var_nhc_vertical_velocity", var_nhc_vertical_velocity_);
+    node_.declare_parameter("min_nhc_forward_speed_mps", 0.5);
+    node_.get_parameter("min_nhc_forward_speed_mps", min_nhc_forward_speed_mps_);
+    node_.declare_parameter("nhc_adaptive_yaw_rate_radps", 0.5);
+    node_.get_parameter("nhc_adaptive_yaw_rate_radps", nhc_adaptive_yaw_rate_radps_);
+    node_.declare_parameter("nhc_adaptive_lateral_accel_mps2", 1.5);
+    node_.get_parameter(
+      "nhc_adaptive_lateral_accel_mps2", nhc_adaptive_lateral_accel_mps2_);
+    node_.declare_parameter("max_nhc_variance_scale", 100.0);
+    node_.get_parameter("max_nhc_variance_scale", max_nhc_variance_scale_);
+    node_.declare_parameter("use_zupt", false);
+    node_.get_parameter("use_zupt", use_zupt_);
+    node_.declare_parameter("zupt_max_angular_velocity_radps", 0.02);
+    node_.get_parameter("zupt_max_angular_velocity_radps", zupt_max_angular_velocity_radps_);
+    node_.declare_parameter("zupt_max_acceleration_error_mps2", 0.2);
+    node_.get_parameter("zupt_max_acceleration_error_mps2", zupt_max_acceleration_error_mps2_);
+    node_.declare_parameter("zupt_max_speed_mps", 0.3);
+    node_.get_parameter("zupt_max_speed_mps", zupt_max_speed_mps_);
+    node_.declare_parameter("zupt_min_stationary_duration_sec", 0.5);
+    node_.get_parameter("zupt_min_stationary_duration_sec", zupt_min_stationary_duration_sec_);
+    node_.declare_parameter("var_zupt_velocity", 0.01);
+    node_.get_parameter("var_zupt_velocity", var_zupt_velocity_);
+    node_.declare_parameter("use_zihr", false);
+    node_.get_parameter("use_zihr", use_zihr_);
+    node_.declare_parameter("var_zihr_gyro", 1.0e-5);
+    node_.get_parameter("var_zihr_gyro", var_zihr_gyro_);
     node_.declare_parameter("use_gnss_course_yaw", false);
     node_.get_parameter("use_gnss_course_yaw", use_gnss_course_yaw_);
     node_.declare_parameter("var_gnss_course_yaw", 0.05);
@@ -326,6 +389,14 @@ struct EkfLocalizationComponent::Impl
       "gnss_position_nis_adaptive_threshold", gnss_position_nis_adaptive_threshold_);
     node_.declare_parameter("max_gnss_position_variance_scale", 1.0);
     node_.get_parameter("max_gnss_position_variance_scale", max_gnss_position_variance_scale_);
+    node_.declare_parameter("gnss_position_robust_loss", "none");
+    node_.get_parameter("gnss_position_robust_loss", gnss_position_robust_loss_name_);
+    node_.declare_parameter("gnss_position_robust_tuning", 2.5);
+    node_.get_parameter("gnss_position_robust_tuning", gnss_position_robust_tuning_);
+    node_.declare_parameter("max_gnss_position_robust_variance_scale", 100.0);
+    node_.get_parameter(
+      "max_gnss_position_robust_variance_scale",
+      max_gnss_position_robust_variance_scale_);
     node_.declare_parameter("gnss_position_reacquisition_dt_sec", 0.0);
     node_.get_parameter("gnss_position_reacquisition_dt_sec", gnss_position_reacquisition_dt_sec_);
     node_.declare_parameter("gnss_position_reacquisition_variance_scale", 1.0);
@@ -415,6 +486,79 @@ struct EkfLocalizationComponent::Impl
         "invalid parameter gnss_input_type='%s'. fallback to default='pose'",
         gnss_input_type_.c_str());
       gnss_input_type_ = "pose";
+    }
+    if (gnss_position_robust_loss_name_ == "huber") {
+      gnss_position_robust_loss_ = core::EKFEstimator::RobustLoss::kHuber;
+    } else if (gnss_position_robust_loss_name_ == "cauchy") {
+      gnss_position_robust_loss_ = core::EKFEstimator::RobustLoss::kCauchy;
+    } else if (gnss_position_robust_loss_name_ != "none") {
+      RCLCPP_WARN(node_.get_logger(), "invalid GNSS robust loss; fallback to none");
+      gnss_position_robust_loss_name_ = "none";
+    }
+    if (!(gnss_position_robust_tuning_ > 0.0) ||
+      !(max_gnss_position_robust_variance_scale_ >= 1.0))
+    {
+      RCLCPP_WARN(node_.get_logger(), "invalid GNSS robust loss parameters; disabling robust loss");
+      gnss_position_robust_loss_ = core::EKFEstimator::RobustLoss::kNone;
+    }
+    if (!gnss_lever_arm_body_.allFinite()) {
+      RCLCPP_WARN(node_.get_logger(), "invalid GNSS lever arm; fallback to zero");
+      gnss_lever_arm_body_.setZero();
+    }
+    if (gnss_navsatfix_use_position_covariance_ &&
+      (!(gnss_navsatfix_min_variance_xy_ > 0.0) ||
+      !(gnss_navsatfix_min_variance_z_ > 0.0) ||
+      !(gnss_navsatfix_max_variance_xy_ >= gnss_navsatfix_min_variance_xy_) ||
+      !(gnss_navsatfix_max_variance_z_ >= gnss_navsatfix_min_variance_z_)))
+    {
+      RCLCPP_WARN(node_.get_logger(), "invalid NavSatFix covariance limits; using fixed variance");
+      gnss_navsatfix_use_position_covariance_ = false;
+    }
+    if (compensate_gnss_delay_ &&
+      (!std::isfinite(gnss_time_offset_sec_) ||
+      !(max_gnss_delay_compensation_sec_ > 0.0) ||
+      !std::isfinite(max_gnss_delay_compensation_sec_)))
+    {
+      RCLCPP_WARN(node_.get_logger(), "invalid GNSS delay parameters; disabling compensation");
+      compensate_gnss_delay_ = false;
+    }
+    if (use_nonholonomic_constraint_) {
+      if (!(var_nhc_lateral_velocity_ > 0.0) || !std::isfinite(var_nhc_lateral_velocity_)) {
+        RCLCPP_WARN(node_.get_logger(), "invalid var_nhc_lateral_velocity; fallback to 0.05");
+        var_nhc_lateral_velocity_ = 0.05;
+      }
+      if (!(var_nhc_vertical_velocity_ > 0.0) || !std::isfinite(var_nhc_vertical_velocity_)) {
+        RCLCPP_WARN(node_.get_logger(), "invalid var_nhc_vertical_velocity; fallback to 0.02");
+        var_nhc_vertical_velocity_ = 0.02;
+      }
+      if (!(min_nhc_forward_speed_mps_ >= 0.0) || !std::isfinite(min_nhc_forward_speed_mps_)) {
+        RCLCPP_WARN(node_.get_logger(), "invalid min_nhc_forward_speed_mps; fallback to 0.5");
+        min_nhc_forward_speed_mps_ = 0.5;
+      }
+      if (!(max_nhc_variance_scale_ >= 1.0) || !std::isfinite(max_nhc_variance_scale_)) {
+        RCLCPP_WARN(node_.get_logger(), "invalid max_nhc_variance_scale; fallback to 100.0");
+        max_nhc_variance_scale_ = 100.0;
+      }
+    }
+    if (use_zupt_ || use_zihr_) {
+      if (!(zupt_max_angular_velocity_radps_ >= 0.0) ||
+        !(zupt_max_acceleration_error_mps2_ >= 0.0) ||
+        !(zupt_max_speed_mps_ >= 0.0) ||
+        !(zupt_min_stationary_duration_sec_ >= 0.0))
+      {
+        RCLCPP_WARN(node_.get_logger(),
+            "invalid stationary detector parameters; disabling updates");
+        use_zupt_ = false;
+        use_zihr_ = false;
+      }
+    }
+    if (use_zupt_ && (!(var_zupt_velocity_ > 0.0) || !std::isfinite(var_zupt_velocity_))) {
+      RCLCPP_WARN(node_.get_logger(), "invalid var_zupt_velocity; disabling ZUPT");
+      use_zupt_ = false;
+    }
+    if (use_zihr_ && (!(var_zihr_gyro_ > 0.0) || !std::isfinite(var_zihr_gyro_))) {
+      RCLCPP_WARN(node_.get_logger(), "invalid var_zihr_gyro; disabling ZIHR");
+      use_zihr_ = false;
     }
     if (gnss_input_type_ == "navsatfix" && !gnss_navsatfix_use_first_fix_as_origin_) {
       if (isValidLatitudeLongitude(
@@ -548,7 +692,8 @@ struct EkfLocalizationComponent::Impl
     {
       RCLCPP_WARN(
         node_.get_logger(),
-        "invalid parameter max_gnss_position_innovation_m=%f. disabling GNSS position innovation gate",
+        "invalid parameter max_gnss_position_innovation_m=%f. disabling GNSS position "
+        "innovation gate",
         max_gnss_position_innovation_m_);
       max_gnss_position_innovation_m_ = 0.0;
     }
@@ -558,7 +703,8 @@ struct EkfLocalizationComponent::Impl
     {
       RCLCPP_WARN(
         node_.get_logger(),
-        "invalid parameter max_gnss_position_innovation_clip_m=%f. disabling GNSS position innovation clipping",
+        "invalid parameter max_gnss_position_innovation_clip_m=%f. disabling GNSS position "
+        "innovation clipping",
         max_gnss_position_innovation_clip_m_);
       max_gnss_position_innovation_clip_m_ = 0.0;
     }
@@ -568,7 +714,8 @@ struct EkfLocalizationComponent::Impl
     {
       RCLCPP_WARN(
         node_.get_logger(),
-        "invalid parameter gnss_position_nis_adaptive_threshold=%f. disabling adaptive GNSS position covariance",
+        "invalid parameter gnss_position_nis_adaptive_threshold=%f. disabling adaptive GNSS "
+        "position covariance",
         gnss_position_nis_adaptive_threshold_);
       gnss_position_nis_adaptive_threshold_ = 0.0;
     }
@@ -588,7 +735,8 @@ struct EkfLocalizationComponent::Impl
     {
       RCLCPP_WARN(
         node_.get_logger(),
-        "invalid parameter gnss_position_reacquisition_dt_sec=%f. disabling GNSS reacquisition scaling",
+        "invalid parameter gnss_position_reacquisition_dt_sec=%f. disabling GNSS "
+        "reacquisition scaling",
         gnss_position_reacquisition_dt_sec_);
       gnss_position_reacquisition_dt_sec_ = 0.0;
     }
@@ -615,7 +763,8 @@ struct EkfLocalizationComponent::Impl
     {
       RCLCPP_WARN(
         node_.get_logger(),
-        "invalid parameter gnss_position_reacquisition_covariance_cap_xy=%f. disabling covariance cap",
+        "invalid parameter gnss_position_reacquisition_covariance_cap_xy=%f. disabling "
+        "covariance cap",
         gnss_position_reacquisition_covariance_cap_xy_);
       gnss_position_reacquisition_covariance_cap_xy_ = 0.0;
     }
@@ -625,7 +774,8 @@ struct EkfLocalizationComponent::Impl
     {
       RCLCPP_WARN(
         node_.get_logger(),
-        "invalid parameter gnss_position_reacquisition_covariance_cap_z=%f. disabling covariance cap",
+        "invalid parameter gnss_position_reacquisition_covariance_cap_z=%f. disabling "
+        "covariance cap",
         gnss_position_reacquisition_covariance_cap_z_);
       gnss_position_reacquisition_covariance_cap_z_ = 0.0;
     }
@@ -635,7 +785,8 @@ struct EkfLocalizationComponent::Impl
     {
       RCLCPP_WARN(
         node_.get_logger(),
-        "invalid parameter gnss_position_reacquisition_velocity_covariance_cap_xy=%f. disabling covariance cap",
+        "invalid parameter gnss_position_reacquisition_velocity_covariance_cap_xy=%f. "
+        "disabling covariance cap",
         gnss_position_reacquisition_velocity_covariance_cap_xy_);
       gnss_position_reacquisition_velocity_covariance_cap_xy_ = 0.0;
     }
@@ -645,7 +796,8 @@ struct EkfLocalizationComponent::Impl
     {
       RCLCPP_WARN(
         node_.get_logger(),
-        "invalid parameter gnss_position_reacquisition_velocity_covariance_cap_z=%f. disabling covariance cap",
+        "invalid parameter gnss_position_reacquisition_velocity_covariance_cap_z=%f. "
+        "disabling covariance cap",
         gnss_position_reacquisition_velocity_covariance_cap_z_);
       gnss_position_reacquisition_velocity_covariance_cap_z_ = 0.0;
     }
@@ -655,7 +807,8 @@ struct EkfLocalizationComponent::Impl
     {
       RCLCPP_WARN(
         node_.get_logger(),
-        "invalid parameter gnss_position_reacquisition_attitude_covariance_cap_rp=%f. disabling covariance cap",
+        "invalid parameter gnss_position_reacquisition_attitude_covariance_cap_rp=%f. "
+        "disabling covariance cap",
         gnss_position_reacquisition_attitude_covariance_cap_rp_);
       gnss_position_reacquisition_attitude_covariance_cap_rp_ = 0.0;
     }
@@ -665,7 +818,8 @@ struct EkfLocalizationComponent::Impl
     {
       RCLCPP_WARN(
         node_.get_logger(),
-        "invalid parameter gnss_position_reacquisition_attitude_covariance_cap_yaw=%f. disabling covariance cap",
+        "invalid parameter gnss_position_reacquisition_attitude_covariance_cap_yaw=%f. "
+        "disabling covariance cap",
         gnss_position_reacquisition_attitude_covariance_cap_yaw_);
       gnss_position_reacquisition_attitude_covariance_cap_yaw_ = 0.0;
     }
@@ -675,7 +829,8 @@ struct EkfLocalizationComponent::Impl
     {
       RCLCPP_WARN(
         node_.get_logger(),
-        "invalid parameter gnss_position_innovation_adaptive_threshold_m=%f. disabling innovation-norm GNSS position covariance",
+        "invalid parameter gnss_position_innovation_adaptive_threshold_m=%f. disabling "
+        "innovation-norm GNSS position covariance",
         gnss_position_innovation_adaptive_threshold_m_);
       gnss_position_innovation_adaptive_threshold_m_ = 0.0;
     }
@@ -702,7 +857,8 @@ struct EkfLocalizationComponent::Impl
     {
       RCLCPP_WARN(
         node_.get_logger(),
-        "invalid parameter gnss_course_yaw_nis_adaptive_threshold=%f. disabling adaptive GNSS course-yaw covariance",
+        "invalid parameter gnss_course_yaw_nis_adaptive_threshold=%f. disabling adaptive "
+        "GNSS course-yaw covariance",
         gnss_course_yaw_nis_adaptive_threshold_);
       gnss_course_yaw_nis_adaptive_threshold_ = 0.0;
     }
@@ -765,6 +921,9 @@ struct EkfLocalizationComponent::Impl
 
     ekf_.setVarImuGyro(var_imu_w_);
     ekf_.setVarImuAcc(var_imu_acc_);
+    ekf_.setUseContinuousProcessNoiseDensity(use_continuous_process_noise_density_);
+    ekf_.setUseSecondOrderStateTransition(use_second_order_state_transition_);
+    ekf_.setUseSecondOrderProcessNoise(use_second_order_process_noise_);
     ekf_.setVarImuGyroBias(var_imu_gyro_bias_);
     if (!ekf_.setInitialGyroBiasCovariance(initial_imu_gyro_bias_covariance_)) {
       RCLCPP_WARN(
@@ -860,6 +1019,7 @@ struct EkfLocalizationComponent::Impl
         // Reset GNSS-derived baselines on re-initialization.
         has_course_base_gnss_ = false;
         has_previous_velocity_gnss_ = false;
+        has_stationary_start_time_ = false;
       };
 
     auto imu_callback =
@@ -963,7 +1123,7 @@ struct EkfLocalizationComponent::Impl
     auto gnss_pose_callback =
       [this](const geometry_msgs::msg::PoseStamped::SharedPtr msg) -> void
       {
-        handleGnssPose(*msg);
+        handleGnssPose(*msg, var_gnss_);
       };
 
     auto gnss_navsatfix_callback =
@@ -974,7 +1134,7 @@ struct EkfLocalizationComponent::Impl
         }
         geometry_msgs::msg::PoseStamped pose_msg;
         if (convertNavSatFixToPose(*msg, pose_msg)) {
-          handleGnssPose(pose_msg);
+          handleGnssPose(pose_msg, getNavSatFixVariance(*msg));
         }
       };
 
@@ -1154,6 +1314,110 @@ struct EkfLocalizationComponent::Impl
         publishUpdateDeltaDebug(imu_msg.header.stamp, 2, 1, state_before, captureState());
       }
     }
+    if (use_nonholonomic_constraint_) {
+      updateNonholonomicConstraint(imu_msg);
+    }
+    if (use_zupt_ || use_zihr_) {
+      updateZeroVelocity(imu_msg, current_time_imu);
+    }
+  }
+
+  void updateZeroVelocity(const sensor_msgs::msg::Imu & imu_msg, const double time_sec)
+  {
+    const Eigen::Vector3d angular_velocity(
+      imu_msg.angular_velocity.x, imu_msg.angular_velocity.y, imu_msg.angular_velocity.z);
+    const Eigen::Vector3d linear_acceleration(
+      imu_msg.linear_acceleration.x,
+      imu_msg.linear_acceleration.y,
+      imu_msg.linear_acceleration.z);
+    const bool stationary = core::isStationaryImu(
+      angular_velocity,
+      linear_acceleration,
+      ekf_.getVelocity().norm(),
+      gravity_mps2_,
+      zupt_max_angular_velocity_radps_,
+      zupt_max_acceleration_error_mps2_,
+      zupt_max_speed_mps_);
+    if (!stationary) {
+      has_stationary_start_time_ = false;
+      return;
+    }
+    if (!has_stationary_start_time_) {
+      stationary_start_time_ = time_sec;
+      has_stationary_start_time_ = true;
+      return;
+    }
+    if (time_sec - stationary_start_time_ < zupt_min_stationary_duration_sec_) {
+      return;
+    }
+
+    if (use_zupt_) {
+      const StateSnapshot state_before = captureState();
+      const Eigen::Vector3d variance = Eigen::Vector3d::Constant(var_zupt_velocity_);
+      const auto status = ekf_.observationUpdateVelocityWithStatus(
+        Eigen::Vector3d::Zero(), variance, true);
+      int status_code = 1;
+      if (status == core::EKFEstimator::ObservationUpdateStatus::kInvalidMeasurement) {
+        status_code = -1;
+      } else if (status == core::EKFEstimator::ObservationUpdateStatus::kInvalidVariance) {
+        status_code = -2;
+      }
+      publishUpdateDeltaDebug(
+        imu_msg.header.stamp, 6, status_code, state_before, captureState());
+    }
+    if (use_zihr_) {
+      const StateSnapshot state_before = captureState();
+      const Eigen::Vector3d variance = Eigen::Vector3d::Constant(var_zihr_gyro_);
+      const auto status = ekf_.observationUpdateGyroBiasWithStatus(
+        angular_velocity, variance);
+      int status_code = 1;
+      if (status == core::EKFEstimator::ObservationUpdateStatus::kInvalidMeasurement) {
+        status_code = -1;
+      } else if (status == core::EKFEstimator::ObservationUpdateStatus::kInvalidVariance) {
+        status_code = -2;
+      }
+      publishUpdateDeltaDebug(
+        imu_msg.header.stamp, 7, status_code, state_before, captureState());
+    }
+  }
+
+  void updateNonholonomicConstraint(const sensor_msgs::msg::Imu & imu_msg)
+  {
+    const Eigen::Quaterniond orientation = ekf_.getOrientation().normalized();
+    const Eigen::Vector3d body_velocity =
+      orientation.toRotationMatrix().transpose() * ekf_.getVelocity();
+    if (!body_velocity.allFinite() ||
+      std::fabs(body_velocity.x()) < min_nhc_forward_speed_mps_)
+    {
+      return;
+    }
+
+    double variance_scale = 1.0;
+    if (nhc_adaptive_yaw_rate_radps_ > 0.0) {
+      const double ratio =
+        std::fabs(imu_msg.angular_velocity.z) / nhc_adaptive_yaw_rate_radps_;
+      variance_scale = std::max(variance_scale, ratio * ratio);
+    }
+    if (nhc_adaptive_lateral_accel_mps2_ > 0.0) {
+      const double ratio =
+        std::fabs(imu_msg.linear_acceleration.y) / nhc_adaptive_lateral_accel_mps2_;
+      variance_scale = std::max(variance_scale, ratio * ratio);
+    }
+    variance_scale = std::min(variance_scale, max_nhc_variance_scale_);
+    const Eigen::Vector2d variance(
+      var_nhc_lateral_velocity_ * variance_scale,
+      var_nhc_vertical_velocity_ * variance_scale);
+    const StateSnapshot state_before = captureState();
+    const auto status = ekf_.observationUpdateBodyVelocityConstraintWithStatus(
+      Eigen::Vector2d::Zero(), variance);
+    int status_code = 1;
+    if (status == core::EKFEstimator::ObservationUpdateStatus::kInvalidMeasurement) {
+      status_code = -1;
+    } else if (status == core::EKFEstimator::ObservationUpdateStatus::kInvalidVariance) {
+      status_code = -2;
+    }
+    publishUpdateDeltaDebug(
+      imu_msg.header.stamp, 5, status_code, state_before, captureState());
   }
 
   void setGnssNavSatFixOrigin(double latitude_deg, double longitude_deg, double altitude_m)
@@ -1212,15 +1476,72 @@ struct EkfLocalizationComponent::Impl
     return true;
   }
 
-  void handleGnssPose(const geometry_msgs::msg::PoseStamped & pose_msg)
+  Eigen::Vector3d getNavSatFixVariance(const sensor_msgs::msg::NavSatFix & fix_msg) const
+  {
+    if (!gnss_navsatfix_use_position_covariance_ ||
+      fix_msg.position_covariance_type == sensor_msgs::msg::NavSatFix::COVARIANCE_TYPE_UNKNOWN)
+    {
+      return var_gnss_;
+    }
+    const Eigen::Vector3d candidate(
+      fix_msg.position_covariance[0],
+      fix_msg.position_covariance[4],
+      fix_msg.position_covariance[8]);
+    const Eigen::Vector3d minimum(
+      gnss_navsatfix_min_variance_xy_,
+      gnss_navsatfix_min_variance_xy_,
+      gnss_navsatfix_min_variance_z_);
+    const Eigen::Vector3d maximum(
+      gnss_navsatfix_max_variance_xy_,
+      gnss_navsatfix_max_variance_xy_,
+      gnss_navsatfix_max_variance_z_);
+    return core::sanitizeMeasurementVariance(candidate, var_gnss_, minimum, maximum);
+  }
+
+  void handleGnssPose(
+    const geometry_msgs::msg::PoseStamped & pose_msg,
+    const Eigen::Vector3d & position_variance)
   {
     if (initial_pose_received_ && use_gnss_) {
-      measurementUpdate(pose_msg, var_gnss_, true);
+      geometry_msgs::msg::PoseStamped body_pose_msg = pose_msg;
+      const Eigen::Vector3d antenna_position(
+        pose_msg.pose.position.x, pose_msg.pose.position.y, pose_msg.pose.position.z);
+      const Eigen::Vector3d body_position = core::removeLeverArmFromPosition(
+        antenna_position, ekf_.getOrientation(), gnss_lever_arm_body_);
+      body_pose_msg.pose.position.x = body_position.x();
+      body_pose_msg.pose.position.y = body_position.y();
+      body_pose_msg.pose.position.z = body_position.z();
+      geometry_msgs::msg::PoseStamped measurement_pose_msg = pose_msg;
+      if (compensate_gnss_delay_ && has_latest_imu_stamp_) {
+        const double imu_time =
+          latest_imu_stamp_.seconds();
+        const double measurement_time =
+          body_pose_msg.header.stamp.sec + body_pose_msg.header.stamp.nanosec * 1.0e-9 +
+          gnss_time_offset_sec_;
+        const double delay = imu_time - measurement_time;
+        if (delay > max_gnss_delay_compensation_sec_) {
+          RCLCPP_WARN_THROTTLE(
+            node_.get_logger(), clock_, 5000,
+            "skip GNSS measurement with excessive delay: %f > %f [sec]",
+            delay, max_gnss_delay_compensation_sec_);
+          return;
+        }
+        if (delay > 0.0) {
+          const Eigen::Vector3d compensated_position =
+            core::extrapolatePositionConstantVelocity(
+            antenna_position, ekf_.getVelocity(), delay);
+          measurement_pose_msg.pose.position.x = compensated_position.x();
+          measurement_pose_msg.pose.position.y = compensated_position.y();
+          measurement_pose_msg.pose.position.z = compensated_position.z();
+        }
+      }
+      measurementUpdate(
+        measurement_pose_msg, position_variance, true, gnss_lever_arm_body_);
       if (use_gnss_velocity_) {
-        updateVelocityFromGnss(pose_msg);
+        updateVelocityFromGnss(body_pose_msg);
       }
       if (use_gnss_course_yaw_) {
-        updateYawFromGnssCourse(pose_msg);
+        updateYawFromGnssCourse(body_pose_msg);
       }
     }
   }
@@ -1419,11 +1740,11 @@ struct EkfLocalizationComponent::Impl
       variance.y(),
       variance.z(),
       covariance.rows() > 0 && covariance.cols() > 0 ? covariance(0, 0) :
-        std::numeric_limits<double>::quiet_NaN(),
+      std::numeric_limits<double>::quiet_NaN(),
       covariance.rows() > 1 && covariance.cols() > 1 ? covariance(1, 1) :
-        std::numeric_limits<double>::quiet_NaN(),
+      std::numeric_limits<double>::quiet_NaN(),
       covariance.rows() > 2 && covariance.cols() > 2 ? covariance(2, 2) :
-        std::numeric_limits<double>::quiet_NaN(),
+      std::numeric_limits<double>::quiet_NaN(),
       raw_nis,
       variance_scale};
     debug_gnss_position_pub_->publish(msg);
@@ -1463,8 +1784,8 @@ struct EkfLocalizationComponent::Impl
       speed,
       variance,
       covariance.rows() > kErrorStateYawIndex && covariance.cols() > kErrorStateYawIndex ?
-        covariance(kErrorStateYawIndex, kErrorStateYawIndex) :
-        std::numeric_limits<double>::quiet_NaN(),
+      covariance(kErrorStateYawIndex, kErrorStateYawIndex) :
+      std::numeric_limits<double>::quiet_NaN(),
       raw_nis,
       variance_scale};
     debug_gnss_course_yaw_pub_->publish(msg);
@@ -1557,7 +1878,8 @@ struct EkfLocalizationComponent::Impl
   void measurementUpdate(
     const geometry_msgs::msg::PoseStamped & pose_msg,
     const Eigen::Vector3d & variance,
-    const bool publish_gnss_debug = false)
+    const bool publish_gnss_debug = false,
+    const Eigen::Vector3d & lever_arm_body = Eigen::Vector3d::Zero())
   {
     has_received_input_ = true;
     current_stamp_ = pose_msg.header.stamp;
@@ -1584,7 +1906,9 @@ struct EkfLocalizationComponent::Impl
       }
     }
     const Eigen::Vector3d position_before_update = ekf_.getPosition();
-    const Eigen::Vector3d innovation = y - position_before_update;
+    const Eigen::Vector3d predicted_measurement =
+      position_before_update + ekf_.getOrientation().normalized() * lever_arm_body;
+    const Eigen::Vector3d innovation = y - predicted_measurement;
     const Eigen::MatrixXd covariance = ekf_.getCovariance();
     const double raw_nis = computePositionNis(innovation, variance, covariance);
     const StateSnapshot state_before = captureState();
@@ -1595,7 +1919,7 @@ struct EkfLocalizationComponent::Impl
 
     if (is_reacquisition_update && gnss_position_reacquisition_reset_position_) {
       core::EKFEstimator::State state = ekf_.getState();
-      state.position = y;
+      state.position = y - state.orientation.normalized() * lever_arm_body;
       if (gnss_position_reacquisition_reset_velocity_) {
         state.velocity = Eigen::Vector3d::Zero();
       }
@@ -1605,7 +1929,8 @@ struct EkfLocalizationComponent::Impl
       if (publish_gnss_debug) {
         publishGnssPositionDebug(
           pose_msg, innovation, raw_nis, 1, variance, covariance, raw_nis, 1.0);
-        publishUpdateDeltaDebug(pose_msg.header.stamp, 4, 1, state_before, captureState(), reset_extra);
+        publishUpdateDeltaDebug(pose_msg.header.stamp, 4, 1, state_before, captureState(),
+            reset_extra);
       }
       return;
     }
@@ -1650,8 +1975,15 @@ struct EkfLocalizationComponent::Impl
       innovation.norm(),
       gnss_position_innovation_adaptive_threshold_m_,
       max_gnss_position_innovation_variance_scale_);
+    const double robust_variance_scale = core::EKFEstimator::computeRobustVarianceScale(
+      std::sqrt(std::max(0.0, raw_nis)),
+      gnss_position_robust_loss_,
+      gnss_position_robust_tuning_,
+      max_gnss_position_robust_variance_scale_);
     const double variance_scale =
-      std::max({nis_variance_scale, innovation_variance_scale, reacquisition_variance_scale});
+      std::max({
+        nis_variance_scale, innovation_variance_scale,
+        reacquisition_variance_scale, robust_variance_scale});
     Eigen::Vector3d update_innovation = innovation;
     if (
       max_gnss_position_innovation_clip_m_ > 0.0 &&
@@ -1660,13 +1992,16 @@ struct EkfLocalizationComponent::Impl
     {
       update_innovation *= max_gnss_position_innovation_clip_m_ / innovation_norm;
     }
-    const Eigen::Vector3d y_update = position_before_update + update_innovation;
+    const Eigen::Vector3d y_update = predicted_measurement + update_innovation;
     const Eigen::Vector3d used_variance = variance * variance_scale;
     const double used_nis = computePositionNis(update_innovation, used_variance, covariance);
     const UpdateDeltaExtra update_extra = computePositionUpdateExtra(
       covariance, innovation, update_innovation, used_variance, raw_nis, used_nis, variance_scale);
 
-    const auto status = ekf_.observationUpdateWithStatus(y_update, used_variance);
+    const auto status = lever_arm_body.squaredNorm() > 0.0 ?
+      ekf_.observationUpdatePositionWithLeverArmWithStatus(
+      y_update, lever_arm_body, used_variance) :
+      ekf_.observationUpdateWithStatus(y_update, used_variance);
     if (status == core::EKFEstimator::ObservationUpdateStatus::kInvalidMeasurement) {
       if (publish_gnss_debug) {
         publishGnssPositionDebug(
@@ -1694,7 +2029,8 @@ struct EkfLocalizationComponent::Impl
     if (publish_gnss_debug) {
       publishGnssPositionDebug(
         pose_msg, innovation, used_nis, 1, used_variance, covariance, raw_nis, variance_scale);
-      publishUpdateDeltaDebug(pose_msg.header.stamp, 1, 1, state_before, captureState(), update_extra);
+      publishUpdateDeltaDebug(pose_msg.header.stamp, 1, 1, state_before, captureState(),
+          update_extra);
     }
   }
 
@@ -2133,15 +2469,27 @@ struct EkfLocalizationComponent::Impl
   std::string gnss_navsatfix_topic_;
   std::string gnss_doppler_velocity_topic_;
   bool gnss_navsatfix_use_first_fix_as_origin_{true};
+  bool gnss_navsatfix_use_position_covariance_{false};
+  double gnss_navsatfix_min_variance_xy_{1.0e-4};
+  double gnss_navsatfix_min_variance_z_{1.0e-4};
+  double gnss_navsatfix_max_variance_xy_{100.0};
+  double gnss_navsatfix_max_variance_z_{100.0};
   double gnss_navsatfix_origin_latitude_{std::numeric_limits<double>::quiet_NaN()};
   double gnss_navsatfix_origin_longitude_{std::numeric_limits<double>::quiet_NaN()};
   double gnss_navsatfix_origin_altitude_{std::numeric_limits<double>::quiet_NaN()};
   Eigen::Vector3d gnss_navsatfix_origin_ecef_{Eigen::Vector3d::Zero()};
+  Eigen::Vector3d gnss_lever_arm_body_{Eigen::Vector3d::Zero()};
+  bool compensate_gnss_delay_{false};
+  double gnss_time_offset_sec_{0.0};
+  double max_gnss_delay_compensation_sec_{0.5};
   bool has_gnss_navsatfix_origin_{false};
   int pub_period_{0};
 
   double var_imu_w_{0.0};
   double var_imu_acc_{0.0};
+  bool use_continuous_process_noise_density_{false};
+  bool use_second_order_state_transition_{false};
+  bool use_second_order_process_noise_{false};
   double var_imu_gyro_bias_{0.0};
   double initial_imu_gyro_bias_covariance_{0.0};
   double tau_gyro_bias_sec_{0.0};
@@ -2153,6 +2501,23 @@ struct EkfLocalizationComponent::Impl
   double var_imu_orientation_rpy_{0.0};
   bool use_flat_ground_{false};
   double var_flat_ground_rp_{0.0};
+  bool use_nonholonomic_constraint_{false};
+  double var_nhc_lateral_velocity_{0.05};
+  double var_nhc_vertical_velocity_{0.02};
+  double min_nhc_forward_speed_mps_{0.5};
+  double nhc_adaptive_yaw_rate_radps_{0.5};
+  double nhc_adaptive_lateral_accel_mps2_{1.5};
+  double max_nhc_variance_scale_{100.0};
+  bool use_zupt_{false};
+  double zupt_max_angular_velocity_radps_{0.02};
+  double zupt_max_acceleration_error_mps2_{0.2};
+  double zupt_max_speed_mps_{0.3};
+  double zupt_min_stationary_duration_sec_{0.5};
+  double var_zupt_velocity_{0.01};
+  bool use_zihr_{false};
+  double var_zihr_gyro_{1.0e-5};
+  bool has_stationary_start_time_{false};
+  double stationary_start_time_{0.0};
   bool use_gnss_course_yaw_{false};
   double var_gnss_course_yaw_{0.0};
   double min_gnss_course_distance_m_{0.0};
@@ -2180,6 +2545,11 @@ struct EkfLocalizationComponent::Impl
   double max_gnss_course_yaw_nis_{0.0};
   double gnss_position_nis_adaptive_threshold_{0.0};
   double max_gnss_position_variance_scale_{1.0};
+  std::string gnss_position_robust_loss_name_{"none"};
+  core::EKFEstimator::RobustLoss gnss_position_robust_loss_{
+    core::EKFEstimator::RobustLoss::kNone};
+  double gnss_position_robust_tuning_{2.5};
+  double max_gnss_position_robust_variance_scale_{100.0};
   double gnss_position_reacquisition_dt_sec_{0.0};
   double gnss_position_reacquisition_variance_scale_{1.0};
   int gnss_position_reacquisition_update_count_{1};

--- a/kalman_filter_localization_ros2/test/test_evaluate_localization.py
+++ b/kalman_filter_localization_ros2/test/test_evaluate_localization.py
@@ -30,17 +30,40 @@
 import contextlib
 import importlib.util
 import io
+import json
 import math
 from pathlib import Path
 import tempfile
 import unittest
+from unittest import mock
+
+import yaml
 
 
 SCRIPT = Path(__file__).parents[1] / 'scripts' / 'evaluate_localization.py'
+COMPARISON_SCRIPT = (
+    Path(__file__).parents[1] / 'scripts' / 'compare_localization_results.py')
+RUNNER_SCRIPT = (
+    Path(__file__).parents[1] / 'scripts' / 'run_urbannav_ablation.py')
+PREPARE_SCRIPT = (
+    Path(__file__).parents[1] / 'scripts' / 'prepare_urbannav_tokyo.py')
 DATA = Path(__file__).parent / 'data'
 SPEC = importlib.util.spec_from_file_location('evaluate_localization', SCRIPT)
 MODULE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(MODULE)
+COMPARISON_SPEC = importlib.util.spec_from_file_location(
+    'compare_localization_results', COMPARISON_SCRIPT)
+COMPARISON_MODULE = importlib.util.module_from_spec(COMPARISON_SPEC)
+with mock.patch.dict('sys.modules', {'evaluate_localization': MODULE}):
+    COMPARISON_SPEC.loader.exec_module(COMPARISON_MODULE)
+RUNNER_SPEC = importlib.util.spec_from_file_location(
+    'run_urbannav_ablation', RUNNER_SCRIPT)
+RUNNER_MODULE = importlib.util.module_from_spec(RUNNER_SPEC)
+RUNNER_SPEC.loader.exec_module(RUNNER_MODULE)
+PREPARE_SPEC = importlib.util.spec_from_file_location(
+    'prepare_urbannav_tokyo', PREPARE_SCRIPT)
+PREPARE_MODULE = importlib.util.module_from_spec(PREPARE_SPEC)
+PREPARE_SPEC.loader.exec_module(PREPARE_MODULE)
 
 
 class EvaluateLocalizationTest(unittest.TestCase):
@@ -124,6 +147,81 @@ class EvaluateLocalizationTest(unittest.TestCase):
                     ])
             self.assertEqual(result, 1)
             self.assertIn('"passed": false', output.read_text(encoding='utf-8'))
+
+    def test_ablation_comparison_uses_first_estimate_as_baseline(self):
+        estimates = [
+            ('baseline', DATA / 'estimate.csv'),
+            ('candidate', DATA / 'estimate.csv'),
+        ]
+        rows = COMPARISON_MODULE.compare(
+            DATA / 'reference.csv', estimates, 0.2, 0.0)
+        self.assertEqual([row['name'] for row in rows], ['baseline', 'candidate'])
+        self.assertAlmostEqual(rows[0]['delta_rmse_3d_m'], 0.0)
+        self.assertAlmostEqual(rows[1]['delta_rmse_3d_m'], 0.0)
+
+    def test_ablation_comparison_writes_csv_and_markdown(self):
+        rows = COMPARISON_MODULE.compare(
+            DATA / 'reference.csv', [('baseline', DATA / 'estimate.csv')],
+            0.2, 0.0)
+        with tempfile.TemporaryDirectory() as directory:
+            csv_path = Path(directory) / 'comparison.csv'
+            markdown_path = Path(directory) / 'comparison.md'
+            COMPARISON_MODULE.write_csv(csv_path, rows)
+            COMPARISON_MODULE.write_markdown(markdown_path, rows)
+            self.assertIn('delta_rmse_3d_m', csv_path.read_text(encoding='utf-8'))
+            markdown = markdown_path.read_text(encoding='utf-8')
+            self.assertIn('| Profile |', markdown)
+            self.assertIn('| baseline |', markdown)
+
+    def test_urbannav_runner_deep_merges_research_parameters(self):
+        base = {'ekf_localization': {'ros__parameters': {
+            'use_gnss': True, 'use_zupt': False}}}
+        override = {'ekf_localization': {'ros__parameters': {
+            'use_zupt': True}}}
+        merged = RUNNER_MODULE.deep_merge(base, override)
+        parameters = merged['ekf_localization']['ros__parameters']
+        self.assertTrue(parameters['use_gnss'])
+        self.assertTrue(parameters['use_zupt'])
+        self.assertFalse(base['ekf_localization']['ros__parameters']['use_zupt'])
+
+    def test_urbannav_runner_dry_run_writes_configs_and_manifest(self):
+        profiles = Path(__file__).parents[1] / 'param' / 'profiles'
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            input_bag = root / 'input_bag'
+            input_bag.mkdir()
+            output = root / 'results'
+            result = RUNNER_MODULE.main([
+                '--input-bag', str(input_bag),
+                '--reference-csv', str(DATA / 'reference.csv'),
+                '--output-dir', str(output),
+                '--base-profile', str(profiles / 'urbannav_tokyo_tuned.yaml'),
+                '--profiles-dir', str(profiles),
+                '--dry-run',
+            ])
+            self.assertEqual(result, 0)
+            manifest = json.loads(
+                (output / 'manifest.json').read_text(encoding='utf-8'))
+            self.assertEqual(
+                [run['name'] for run in manifest['runs']],
+                ['baseline', 'nhc', 'robust', 'full'])
+            full = yaml.safe_load(
+                (output / 'configs' / 'full.yaml').read_text(encoding='utf-8'))
+            parameters = full['ekf_localization']['ros__parameters']
+            self.assertTrue(parameters['use_gnss'])
+            self.assertTrue(parameters['use_zupt'])
+
+    def test_urbannav_geodetic_origin_maps_to_zero_enu(self):
+        origin = (35.62931853, 139.78712595, 44.6995)
+        ecef = PREPARE_MODULE.geodetic_to_ecef(*origin)
+        enu = PREPARE_MODULE.ecef_to_enu(
+            ecef, ecef, origin[0], origin[1])
+        self.assertEqual(enu, (0.0, 0.0, 0.0))
+
+    def test_urbannav_gps_stamp_is_continuous_across_weeks(self):
+        before = PREPARE_MODULE.gps_stamp(2032, 604799.9)
+        after = PREPARE_MODULE.gps_stamp(2033, 0.1)
+        self.assertAlmostEqual(after - before, 0.2, places=5)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- add adaptive NHC, ZUPT/ZIHR, GNSS lever-arm and delay handling, continuous process noise, second-order propagation, and robust GNSS updates
- add baseline/NHC/robust/full research profiles and CSV comparison tooling
- add reproducible UrbanNav Tokyo preparation and four-profile ablation runner
- document the evaluation workflow and expand regression coverage

## UrbanNav Tokyo result

On the Odaiba sequence, the robust profile reduced 3D RMSE from 197.48 m to 172.84 m (12.5%). The untuned NHC and full profiles regressed, identifying their parameters as follow-up tuning work. The sequence includes GNSS outages up to 81.8 seconds.

## Validation

- `colcon build --symlink-install`
- `colcon test`
- `colcon test-result --verbose`: 123 tests, 0 errors, 0 failures, 11 skipped
- installed ROS commands and UrbanNav dry-run verified
- four Odaiba trajectory CSVs and comparison artifacts generated
