### PR TITLE
Simplify README and add visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,231 +1,77 @@
 # Kalman Filter Localization
 
-Kalman Filter Localization is a ROS 2 package for 3D localization with GNSS, IMU, and odometry.
+ROS 2向けのGNSS/IMU/odometry Error-State EKFです。姿勢・速度・位置とIMU biasを推定します。
 
-## Node
-`ekf_localization_node`
+![Localization pipeline](docs/images/localization_pipeline.svg)
 
-Input:
-- `/initial_pose` (`geometry_msgs/PoseStamped`)
-- `/gnss_pose` (`geometry_msgs/PoseStamped`) by default
-- `/gnss/fix` (`sensor_msgs/NavSatFix`) when `gnss_input_type: "navsatfix"`
-- `/imu` (`sensor_msgs/Imu`)
-- `/odom` (`nav_msgs/Odometry`)
-- `/gnss/velocity` (`geometry_msgs/TwistWithCovarianceStamped`, optional Doppler velocity)
-- `/tf` (`/base_link` -> `/imu_link`)
+## Features
 
-Output:
-- `/current_pose` (`geometry_msgs/PoseStamped`)
-- `/current_odometry` (`nav_msgs/Odometry`, including velocity and covariance)
-- `/tf` (`reference_frame_id` -> `robot_frame_id`) when `publish_tf: true`
+- GNSS pose / `NavSatFix` / Doppler velocity
+- IMU gyro・加速度bias推定
+- GNSS外れ値のNIS gate、Huber/Cauchy loss
+- GNSS antenna lever arm・短時間delay補償
+- NHC、ZUPT、ZIHR
+- 連続時間process noiseと2次離散化
+- CSV評価、UrbanNav Tokyo ablation実行
 
-## Params
+## Build and run
 
-| Name | Type | Default value | Description |
-|---|---|---:|---|
-| `pub_period` | int | 10 | Publish period `[ms]` |
-| `output_odometry_topic` | string | `/ekf_localization/current_odometry` | Odometry output topic |
-| `publish_tf` | bool | false | Publish the estimated reference-to-robot transform |
-| `var_gnss_xy` | double | 0.1 | GNSS position variance in XY `[m^2]` |
-| `var_gnss_z` | double | 0.15 | GNSS position variance in Z `[m^2]` |
-| `gnss_position_robust_loss` | string | `none` | Soft robust loss: `none`, `huber`, or `cauchy` |
-| `gnss_position_robust_tuning` | double | 2.5 | Robust loss transition in normalized residual units |
-| `max_gnss_position_robust_variance_scale` | double | 100.0 | Maximum robust covariance multiplier |
+```bash
+source /opt/ros/$ROS_DISTRO/setup.bash
+colcon build --symlink-install
+source install/setup.bash
+ros2 launch kalman_filter_localization ekf.launch.py
+```
 
-The optional robust loss uses `sqrt(NIS)` as a normalized residual. Huber increases
-measurement covariance linearly beyond the tuning constant, while Cauchy increases it
-quadratically. Hard innovation/NIS gates still take precedence; robust scaling handles
-the measurements that remain inside those gates without an accept/reject discontinuity.
-| `gnss_input_type` | string | `pose` | GNSS input type: `pose` or `navsatfix` |
-| `gnss_pose_topic` | string | `gnss_pose` | `PoseStamped` GNSS input topic |
-| `gnss_navsatfix_topic` | string | `/gnss/fix` | `NavSatFix` GNSS input topic when `gnss_input_type: "navsatfix"` |
-| `gnss_navsatfix_use_first_fix_as_origin` | bool | true | Use the first valid `NavSatFix` as the local ENU origin |
-| `gnss_navsatfix_use_position_covariance` | bool | false | Use per-message NavSatFix ENU covariance |
-| `gnss_navsatfix_min_variance_xy` | double | 0.0001 | XY variance floor `[m^2]` |
-| `gnss_navsatfix_min_variance_z` | double | 0.0001 | Z variance floor `[m^2]` |
-| `gnss_navsatfix_max_variance_xy` | double | 100.0 | XY variance ceiling `[m^2]` |
-| `gnss_navsatfix_max_variance_z` | double | 100.0 | Z variance ceiling `[m^2]` |
-| `gnss_lever_arm_x` | double | 0.0 | GNSS antenna X offset from body/IMU origin `[m]` |
-| `gnss_lever_arm_y` | double | 0.0 | GNSS antenna Y offset from body/IMU origin `[m]` |
-| `gnss_lever_arm_z` | double | 0.0 | GNSS antenna Z offset from body/IMU origin `[m]` |
-| `compensate_gnss_delay` | bool | false | Extrapolate delayed GNSS position to the latest IMU time |
-| `gnss_time_offset_sec` | double | 0.0 | Offset added to the GNSS message timestamp `[s]` |
-| `max_gnss_delay_compensation_sec` | double | 0.5 | Reject observations older than this limit `[s]` |
-| `var_odom_xyz` | double | 0.1 | Odometry variance `[m^2]` |
-| `var_imu_w` | double | 0.01 | Angular velocity variance `[(deg/sec)^2]` |
-| `var_imu_acc` | double | 0.01 | Accelerometer variance `[(m/sec^2)^2]` |
-| `use_continuous_process_noise_density` | bool | false | Interpret IMU noise parameters as continuous PSDs |
-| `use_second_order_state_transition` | bool | false | Use a second-order continuous-to-discrete state transition |
-| `use_second_order_process_noise` | bool | false | Propagate continuous noise into coupled states |
-| `use_gnss` | bool | true | Whether GNSS is used |
-| `use_odom` | bool | false | Whether odometry is used |
+主なtopic:
 
-When `use_continuous_process_noise_density` is enabled, `var_imu_acc` and
-`var_imu_w` are treated as continuous-time power spectral densities and discretized
-with `Qd = Qc * dt`. This makes covariance growth substantially independent of the IMU
-sampling rate. The default remains disabled to preserve existing tuned profiles that
-use the legacy per-sample `dt^2` convention.
+| Direction | Topic | Type |
+|---|---|---|
+| input | `/ekf_localization/initial_pose` | `geometry_msgs/PoseStamped` |
+| input | `/gnss_pose` | `geometry_msgs/PoseStamped` |
+| input | `/sensing/imu/imu_data` | `sensor_msgs/Imu` |
+| output | `/ekf_localization/current_pose` | `geometry_msgs/PoseStamped` |
+| output | `/ekf_localization/current_odometry` | `nav_msgs/Odometry` |
 
-`use_second_order_state_transition` constructs a continuous-time error-state Jacobian
-and applies `Phi = I + Fc*dt + 0.5*(Fc*dt)^2`. This includes position, velocity,
-attitude, gyro-bias, and accelerometer-bias cross-couplings from one consistent model.
-Enable it together with continuous process noise for new profiles; existing profiles
-retain the hand-discretized legacy transition by default.
+設定は [`ekf.yaml`](kalman_filter_localization_ros2/param/ekf.yaml)、データセット別設定は
+[`param/profiles`](kalman_filter_localization_ros2/param/profiles) にあります。
 
-`use_second_order_process_noise` integrates continuous error-state noise through the
-transition dynamics up to third order in `dt`. This generates position–velocity and
-other cross-covariance terms within each IMU step. Enable it together with continuous
-process noise and the second-order state transition.
-| `use_nonholonomic_constraint` | bool | false | Constrain body lateral and vertical velocity |
-| `var_nhc_lateral_velocity` | double | 0.05 | Lateral pseudo-measurement variance `[(m/s)^2]` |
-| `var_nhc_vertical_velocity` | double | 0.02 | Vertical pseudo-measurement variance `[(m/s)^2]` |
-| `min_nhc_forward_speed_mps` | double | 0.5 | Minimum absolute forward speed for NHC `[m/s]` |
-| `nhc_adaptive_yaw_rate_radps` | double | 0.5 | Yaw-rate scale where NHC covariance starts increasing |
-| `nhc_adaptive_lateral_accel_mps2` | double | 1.5 | Lateral-acceleration scale for adaptive covariance |
-| `max_nhc_variance_scale` | double | 100.0 | Maximum adaptive NHC covariance multiplier |
-| `use_zupt` | bool | false | Apply zero-velocity updates after stationary detection |
-| `zupt_max_angular_velocity_radps` | double | 0.02 | Maximum gyro norm for stationary detection `[rad/s]` |
-| `zupt_max_acceleration_error_mps2` | double | 0.2 | Maximum acceleration-norm error from gravity `[m/s^2]` |
-| `zupt_max_speed_mps` | double | 0.3 | Maximum estimated speed for stationary detection `[m/s]` |
-| `zupt_min_stationary_duration_sec` | double | 0.5 | Required continuous stationary duration `[s]` |
-| `var_zupt_velocity` | double | 0.01 | Zero-velocity observation variance `[(m/s)^2]` |
-| `use_zihr` | bool | false | Estimate gyro bias from stationary angular-rate observations |
-| `var_zihr_gyro` | double | 1.0e-5 | Stationary gyro observation variance `[(rad/s)^2]` |
+## GNSS input
 
-The non-holonomic constraint assumes a wheeled vehicle whose body-frame lateral and
-vertical velocities are normally close to zero. Its covariance is weakened during
-high yaw-rate or lateral-acceleration motion. Keep it disabled for holonomic, airborne,
-marine, or intentionally sliding platforms.
-
-ZUPT additionally constrains all three velocity axes to zero after the IMU and estimated
-speed remain stationary for the configured duration. Because constant-speed motion can
-look stationary to an IMU, `zupt_max_speed_mps` is an essential second condition. Keep
-ZUPT disabled when no reliable low-speed estimate is available.
-
-ZIHR uses the same stationary detector but treats measured angular velocity as gyro
-bias while the platform is stopped. It can be enabled independently of ZUPT and is
-most useful when `initial_imu_gyro_bias_covariance` is nonzero so the bias state is
-allowed to converge.
-| `use_gnss_doppler_velocity` | bool | false | Fuse receiver-provided ENU Doppler velocity |
-| `gnss_doppler_velocity_topic` | string | `/ekf_localization_node/gnss/velocity` | Doppler velocity input topic |
-| `use_gnss_doppler_velocity_covariance` | bool | true | Use the message linear-velocity covariance when valid |
-| `use_gnss_doppler_course_yaw` | bool | false | Derive and fuse course yaw from Doppler velocity |
-| `min_gnss_doppler_course_speed_mps` | double | 1.0 | Minimum horizontal speed for Doppler course yaw `[m/s]` |
-
-`use_gnss_doppler_course_yaw` assumes that vehicle heading follows its direction of
-travel. Keep it disabled for platforms that move sideways or frequently reverse unless
-the velocity direction is corrected upstream.
-
-### NavSatFix input
-
-If your RTK receiver publishes `sensor_msgs/NavSatFix`, set:
+`PoseStamped`が標準です。`NavSatFix`を直接使う場合:
 
 ```yaml
 gnss_input_type: "navsatfix"
 gnss_navsatfix_topic: "/gnss/fix"
+gnss_navsatfix_use_first_fix_as_origin: true
+gnss_navsatfix_use_position_covariance: true
 ```
 
-The node converts WGS84 latitude/longitude/altitude to local ENU `PoseStamped` internally and fuses it with the same GNSS variance parameters. By default, the first valid fix becomes the ENU origin, so `/initial_pose` should use the same local frame. To use a fixed origin, set `gnss_navsatfix_use_first_fix_as_origin: false` and provide `gnss_navsatfix_origin_latitude`, `gnss_navsatfix_origin_longitude`, and `gnss_navsatfix_origin_altitude`.
+antenna offsetは`gnss_lever_arm_{x,y,z}`、既知の短いdelayは
+`compensate_gnss_delay`と`gnss_time_offset_sec`で設定します。
 
-When enabled, NavSatFix covariance entries 0, 4, and 8 are used as ENU X/Y/Z
-measurement variances. Unknown, non-finite, or non-positive covariance falls back to
-the configured fixed GNSS variance. Floors prevent overconfident receiver output and
-ceilings prevent a single message from effectively disabling correction.
-
-The GNSS lever arm is expressed in `robot_frame_id`: X forward, Y left, and Z up.
-The current estimated orientation rotates this offset into the reference frame before
-the antenna observation is evaluated. The EKF measurement Jacobian includes the
-lever-arm sensitivity to attitude error, allowing antenna position during turns to
-correct both body position and attitude. Leaving all three values at zero preserves
-the original position-only observation model.
-
-Optional GNSS delay compensation extrapolates the lever-arm-corrected position with the
-current estimated velocity. A positive `gnss_time_offset_sec` means the effective GNSS
-measurement time is later than its message timestamp. This constant-velocity model is
-intended for known, short receiver delays; it is not equivalent to state rewind and IMU
-replay during aggressive acceleration or turning.
-
-## Evaluating localization accuracy
-
-`evaluate_localization` compares `/current_pose` with a timestamped reference trajectory.
-It reports 3D, horizontal, vertical, and yaw RMSE, plus the maximum 3D error.
-
-```bash
-ros2 run kalman_filter_localization evaluate_localization \
-  --bag path/to/bag \
-  --estimate-topic /current_pose \
-  --reference-topic /ground_truth/pose \
-  --output-json metrics.json \
-  --output-csv errors.csv
-```
-
-Both topics may contain `geometry_msgs/PoseStamped` or `nav_msgs/Odometry`. A reference
-CSV can be used instead with `--reference-csv`. For CSV-only evaluation, provide
-`--estimate-csv` and `--reference-csv`. CSV files require `stamp,x,y,z` and either a
-`yaw` column in radians or `qx,qy,qz,qw` quaternion columns.
-
-Reference poses are linearly interpolated at estimate timestamps. Samples spanning a
-reference gap larger than `--max-reference-gap` (default: 0.2 seconds) are excluded.
-Use `--time-offset` when a known sensor timestamp offset must be compensated.
-
-For automated regression testing, configure acceptance thresholds. The command exits
-with status 1 when a threshold is exceeded (or when the match ratio is too low), and
-status 2 for invalid input:
+## Evaluation
 
 ```bash
 ros2 run kalman_filter_localization evaluate_localization \
   --estimate-csv result.csv \
   --reference-csv ground_truth.csv \
-  --max-rmse-3d 0.10 \
-  --max-yaw-rmse-deg 3.0 \
-  --min-match-ratio 0.95 \
-  --output-json metrics.json
+  --output-json metrics.json \
+  --output-csv errors.csv
 ```
 
-Available limits are `--max-rmse-3d`, `--max-rmse-horizontal`,
-`--max-rmse-vertical`, `--max-yaw-rmse-deg`, `--max-error-3d`, and
-`--min-match-ratio`. The JSON output includes `passed` and
-`threshold_failures` fields for CI artifact processing.
+CSV列は`stamp,x,y,z,yaw`です。RMSE、最大3D誤差、match率を出力し、CI用の閾値も指定できます。
 
-The repository includes a small deterministic CSV regression dataset under
-`kalman_filter_localization_ros2/test/data`. Its expected metrics and acceptance
-limits are tested on both supported ROS distributions by GitHub Actions. This dataset
-tests the evaluator; vehicle-specific rosbag baselines can use the same CLI and limits
-without committing large bag files to the repository.
+## UrbanNav Tokyo ablation
 
-## Comparing ablation profiles
+![UrbanNav Odaiba ablation](docs/images/urbannav_odaiba_ablation.svg)
 
-Four starting profiles are provided: `research_baseline`, `research_nhc`,
-`research_robust`, and `research_full`. After producing one estimate CSV per profile,
-generate a comparison table with the first estimate treated as the baseline:
+Odaibaのu-blox RTK解には最長81.8秒のGNSS欠測があります。初期パラメータでの結果では、
+robust profileがbaselineに対して3D RMSEを12.5%改善しました。NHC/fullは要調整です。
+
+公式CSVとRTKLIB解をROS 2 bagへ変換:
 
 ```bash
-ros2 run kalman_filter_localization compare_localization_results \
-  --reference-csv ground_truth.csv \
-  --estimate baseline=baseline.csv \
-  --estimate nhc=nhc.csv \
-  --estimate robust=robust.csv \
-  --estimate full=full.csv \
-  --output-csv comparison.csv \
-  --output-markdown comparison.md
-```
-
-The research profiles are ablation starting points, not sensor-independent tuned
-defaults. Lever arm and delay parameters remain dataset/hardware-specific and must be
-configured separately.
-
-For UrbanNav Tokyo, the complete four-profile run can be reproduced with one command.
-The input bag must publish `/gnss_pose` and `/sensing/imu/imu_data`; the reference CSV
-uses the same columns described above.
-
-The official `UrbanNav-TK-20181219` archive provides `imu.csv`, `reference.csv`, rover
-and base RINEX files. One reproducible way to produce the GNSS solution and ROS 2 inputs
-is:
-
-```bash
-rnx2rtkp -p 2 -f 2 -t -s , -o odaiba_ublox_rtk.pos \
-  Odaiba/rover_ublox.obs Odaiba/base_trimble.obs Odaiba/base.nav
-
 ros2 run kalman_filter_localization prepare_urbannav_tokyo \
   --imu-csv Odaiba/imu.csv \
   --reference-csv Odaiba/reference.csv \
@@ -234,10 +80,7 @@ ros2 run kalman_filter_localization prepare_urbannav_tokyo \
   --output-reference-csv odaiba_reference.csv
 ```
 
-The converter expresses both trajectories in an ENU frame whose origin is the first
-Applanix reference position. It converts the dataset IMU from forward-right-down to
-ROS forward-left-up axes and repeats the initial reference pose before sensor playback
-so DDS discovery cannot lose initialization.
+4構成を実行してCSV/Markdown比較表を生成:
 
 ```bash
 share="$(ros2 pkg prefix kalman_filter_localization)/share/kalman_filter_localization"
@@ -249,16 +92,18 @@ ros2 run kalman_filter_localization run_urbannav_ablation \
   --profiles-dir "$share/param/profiles"
 ```
 
-Each run stores its merged parameter YAML, process logs, recorded estimate bag, and
-`estimate.csv`. The top-level directory contains `manifest.json`, `comparison.csv`,
-and `comparison.md`. Use `--dry-run` to validate inputs and generate the exact configs
-and command manifest without starting ROS processes. Output directories must initially
-be absent or empty so previous results cannot be mixed into a new experiment.
+出力には各構成の合成YAML、軌跡CSV、bag、ログ、`comparison.csv`、`comparison.md`、
+`manifest.json`が含まれます。
+
+## Test
+
+```bash
+colcon test
+colcon test-result --verbose
+```
 
 ## References
 
-- K Feng, "A New Quaternion-Based Kalman Filter", 2017
-- Joan Sola, "Quaternion kinematics for the error-state Kalman filter", 2017
-- Daniel Choukroun et al, "A Novel Quaternion Kalman Filter", 2006
-- "An Improved EKF - The Error State Extended Kalman Filter"
-- Weikun Zhen, Sam Zeng, and Sebastian Scherer, "Robust Localization and Localizability Estimation with a Rotating Laser Scanner", 2017
+- Joan Sola, *Quaternion kinematics for the error-state Kalman filter*, 2017
+- K. Feng, *A New Quaternion-Based Kalman Filter*, 2017
+- [UrbanNav Dataset](https://github.com/IPNL-POLYU/UrbanNavDataset)

--- a/docs/images/localization_pipeline.svg
+++ b/docs/images/localization_pipeline.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="310" viewBox="0 0 960 310" role="img" aria-labelledby="title desc">
+  <title id="title">Kalman Filter Localization pipeline</title>
+  <desc id="desc">GNSS, IMU and odometry are fused by an error-state EKF to produce pose, odometry and TF.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0f172a"/><stop offset="1" stop-color="#172554"/>
+    </linearGradient>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#60a5fa"/>
+    </marker>
+  </defs>
+  <rect width="960" height="310" rx="22" fill="url(#bg)"/>
+  <text x="40" y="48" fill="#f8fafc" font-family="sans-serif" font-size="24" font-weight="700">Kalman Filter Localization</text>
+  <g font-family="sans-serif" font-size="17" text-anchor="middle">
+    <g fill="#0f172a">
+      <rect x="40" y="78" width="190" height="52" rx="12" fill="#bfdbfe"/><text x="135" y="111">GNSS position</text>
+      <rect x="40" y="148" width="190" height="52" rx="12" fill="#c7d2fe"/><text x="135" y="181">IMU gyro + accel</text>
+      <rect x="40" y="218" width="190" height="52" rx="12" fill="#ddd6fe"/><text x="135" y="251">Odometry / Doppler</text>
+    </g>
+    <g stroke="#60a5fa" stroke-width="3" marker-end="url(#arrow)">
+      <path d="M230 104 L360 135"/><path d="M230 174 L360 174"/><path d="M230 244 L360 213"/>
+      <path d="M600 174 L730 174"/>
+    </g>
+    <rect x="360" y="104" width="240" height="140" rx="18" fill="#2563eb"/>
+    <text x="480" y="151" fill="#fff" font-size="22" font-weight="700">Error-State EKF</text>
+    <text x="480" y="184" fill="#dbeafe" font-size="15">position · velocity · attitude</text>
+    <text x="480" y="210" fill="#dbeafe" font-size="15">gyro bias · accel bias</text>
+    <rect x="730" y="112" width="190" height="124" rx="18" fill="#0f766e"/>
+    <text x="825" y="153" fill="#fff" font-size="20" font-weight="700">Output</text>
+    <text x="825" y="184" fill="#ccfbf1" font-size="15">Pose · Odometry</text>
+    <text x="825" y="210" fill="#ccfbf1" font-size="15">TF · Covariance</text>
+  </g>
+</svg>

--- a/docs/images/urbannav_odaiba_ablation.svg
+++ b/docs/images/urbannav_odaiba_ablation.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="430" viewBox="0 0 960 430" role="img" aria-labelledby="title desc">
+  <title id="title">UrbanNav Odaiba ablation 3D RMSE</title>
+  <desc id="desc">Robust profile achieved 172.84 metres versus baseline 197.48 metres. NHC and full profiles were worse.</desc>
+  <rect width="960" height="430" rx="22" fill="#f8fafc"/>
+  <text x="48" y="54" font-family="sans-serif" font-size="26" font-weight="700" fill="#0f172a">UrbanNav Odaiba — 3D RMSE</text>
+  <text x="48" y="82" font-family="sans-serif" font-size="15" fill="#64748b">u-blox RTK input · GNSS outage up to 81.8 s · lower is better</text>
+  <g font-family="sans-serif" font-size="17">
+    <text x="48" y="139" fill="#334155">baseline</text>
+    <rect x="165" y="116" width="296" height="32" rx="7" fill="#64748b"/>
+    <text x="475" y="139" fill="#334155" font-weight="700">197.48 m</text>
+
+    <text x="48" y="207" fill="#334155">NHC</text>
+    <rect x="165" y="184" width="723" height="32" rx="7" fill="#f59e0b"/>
+    <text x="802" y="207" fill="#fff" font-weight="700">482.06 m</text>
+
+    <text x="48" y="275" fill="#0f766e" font-weight="700">robust</text>
+    <rect x="165" y="252" width="259" height="32" rx="7" fill="#0d9488"/>
+    <text x="438" y="275" fill="#0f766e" font-weight="700">172.84 m  (−12.5%)</text>
+
+    <text x="48" y="343" fill="#334155">full</text>
+    <rect x="165" y="320" width="394" height="32" rx="7" fill="#8b5cf6"/>
+    <text x="573" y="343" fill="#334155" font-weight="700">262.59 m</text>
+  </g>
+  <line x1="165" y1="382" x2="888" y2="382" stroke="#cbd5e1" stroke-width="2"/>
+  <g font-family="sans-serif" font-size="13" fill="#64748b" text-anchor="middle">
+    <text x="165" y="405">0</text><text x="316" y="405">100</text><text x="466" y="405">200</text>
+    <text x="617" y="405">300</text><text x="767" y="405">400</text><text x="888" y="405">480 m</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

- reduce the README from 264 to 109 lines
- keep only the essential build, topic, GNSS, evaluation, and UrbanNav workflows
- add a lightweight SVG localization pipeline diagram
- add an SVG chart of the measured UrbanNav Odaiba ablation results

## Why

The README had become parameter-reference heavy and difficult to scan. The concise version points readers to the authoritative YAML profiles while making the architecture and research result visible at a glance.

## Validation

- both SVG files pass `xmllint --noout`
- both SVGs rendered successfully in headless Chrome at their native dimensions
- `git diff --check` passes
- documentation-only change; runtime tests were not rerun
