### PR TITLE
Add fixed-lag RTS smoother as an offline EKF oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,25 @@ ros2 run kalman_filter_localization kf_doctor \
   --output-profile .data/doctor/profile.yaml
 ```
 
+## Fixed-lag smoothing oracle
+
+An optional fixed-lag RTS smoother re-conditions past EKF states on the future
+measurements, giving a reference trajectory for EKF error analysis. It requires
+measurement replay and publishes `smoothed_pose`:
+
+```yaml
+enable_measurement_replay: true
+enable_fixed_lag_smoothing: true
+fixed_lag_duration_sec: 5.0
+fixed_lag_node_subsample: 10   # one node per 10 IMU samples (real-time window)
+```
+
+Output topic: `/ekf_localization/smoothed_pose` (`geometry_msgs/PoseStamped`).
+On an Applanix open-sky segment the smoothed track reduced the GNSS ground-truth
+3D error from 15.4 m (filter) to 1.9 m. See
+[`docs/fixed_lag_smoothing.md`](docs/fixed_lag_smoothing.md) for the math,
+subsampling, and integration details.
+
 The inferred IMU noise values are explicitly heuristic estimates from detected
 stationary samples. Allan variance and the calibration checklist remain the
 authoritative path for production noise parameters.

--- a/docs/fixed_lag_smoothing.md
+++ b/docs/fixed_lag_smoothing.md
@@ -1,0 +1,145 @@
+# Fixed-lag RTS smoother as an offline EKF oracle
+
+Final update: 2026-08-08
+
+## Overview
+
+`kalman_filter_localization_core/include/kalman_filter_localization/core/fixed_lag_smoother.hpp`
+implements a fixed-lag Rauch-Tung-Striebel (RTS) smoother over the ESKF. It is an
+**offline oracle** for EKF error analysis (plan.md Phase 7): while a filter only
+uses past measurements, the smoother re-conditions every retained state on the
+measurements that arrived *after* it, so past states get corrected by future
+information.
+
+The smoothing track reuses the same `EKFEstimator` dynamics and records, for every
+recorded node:
+
+- the nominal state right after propagation (before any measurement update),
+- the post-update state and covariance,
+- the discrete transition / process-covariance pair `(Phi, Qd)` the filter
+  actually used (`EKFEstimator::getLastDiscreteModel`).
+
+A backward RTS pass then yields smoothed states that are consistent with the
+filter's linearization.
+
+## Math
+
+For error-state ESKF with right-multiplicative quaternion error, the RTS backward
+recursion over nodes `0..N-1` is:
+
+```
+P_{k+1|k} = Phi_k P_k Phi_k^T + Qd_k          (stored as predicted_covariance)
+C_k       = P_k Phi_k^T (P_{k+1|k})^{-1}
+x_k^s     = x_k (+) C_k ( x_{k+1}^s (-) x_{k+1|k} )
+P_k^s     = P_k + C_k ( P_{k+1}^s - P_{k+1|k} ) C_k^T
+```
+
+where `(-)` is the error-state difference (position/velocity difference, `Log`
+of the quaternion error, bias difference) and `(+)` is the error-state injection
+(right quaternion multiplication), matching `EKFEstimator::applyErrorState`.
+
+The last node is initialized to the filter estimate (`x_N^s = x_N`, `P_N^s = P_N`).
+
+## Operation modes
+
+- **Fixed-lag** (`lag_sec > 0`): the retained window is bounded in time. When the
+  oldest node leaves the window it is smoothed against the current window,
+  emitted through `popSmoothed()`, and dropped. Memory is `O(lag)`.
+- **Batch** (`lag_sec <= 0`): all nodes are kept until `finalize()`, which runs
+  one backward pass and emits the whole smoothed trajectory.
+
+## Node subsampling
+
+A plain fixed-lag RTS recomputes an `O(window)` backward pass per IMU step. At
+100 Hz IMU and a 5 s window (500 nodes) this blocks the IMU callback, which in
+turn starves the main replay (QoS depth 1 drops IMU and the filter wedges on
+`dt > max_imu_dt`).
+
+`setNodeSubsample(N)` records one node every `N`-th IMU sample and **composes**
+the per-step discrete models over the interval:
+
+```
+Phi_composed = Phi_N * ... * Phi_1
+Qd_composed  = Phi_N * ( ... ( Phi_2 * Qd_1 * Phi_2^T ) ... ) * Phi_N^T + ... + Qd_N
+```
+
+The composed pair is stored in the node, so one RTS step spans `N` IMU steps and
+the window (and the per-step backward-pass cost) shrink by `N`. Node subsampling
+does not change the filter's own propagation; `EKFEstimator` still integrates
+every IMU sample.
+
+## Measurement timing
+
+Measurements whose sensor time equals the latest node boundary are applied
+immediately and the node's post-update state/covariance is refreshed. All other
+in-window measurements are deferred to the next node so that a node's
+`predicted_state` / `predicted_covariance` stay measurement-free (as RTS
+requires). Out-of-window, duplicate, and reverse-stamped events are counted and
+rejected; delayed out-of-order rewind is the job of `EskfReplay` in the live
+pipeline, not of this oracle.
+
+## ROS 2 integration
+
+`ekf_localization_node` (`ekf_localization_component.cpp`) exposes:
+
+| Parameter | Default | Meaning |
+|---|---|---|
+| `enable_fixed_lag_smoothing` | `false` | enable the smoothing track |
+| `fixed_lag_duration_sec` | `5.0` | smoothing lag window |
+| `fixed_lag_node_subsample` | `1` | record one node every N IMU samples |
+
+When enabled, the node runs a parallel `EKFEstimator` (`smoother_ekf_`) driven by
+the same IMU stream and the same measurement functions as the main replay, and
+publishes smoothed poses on:
+
+```
+/ekf_localization/smoothed_pose   (geometry_msgs/PoseStamped)
+```
+
+Smoothing requires `enable_measurement_replay: true` (the in-order,
+sensor-time-aligned measurement feed). If smoothing is enabled without replay, a
+warning is logged and the smoother stays inactive.
+
+Initial pose / stationary initialization set the smoother's state to match the
+main filter, and reset the smoother so the two tracks share the same starting
+point.
+
+## Real-data result
+
+Applanix open-sky bag (120 s window), `research_smoothing.yaml` profile
+(`propagation_model: fast`, replay enabled, subsample 10):
+
+| Track | GNSS ground-truth mean 3D error |
+|---|---:|
+| EKF filter (`/ekf_localization/current_pose`) | 15.4 m |
+| Fixed-lag smoothed (`/ekf_localization/smoothed_pose`) | 1.9 m |
+
+The smoother improves the ground-truth error by roughly 8x by re-conditioning past
+states on future GNSS updates.
+
+The smoothing forward track runs its **own** stationary detector and vehicle model
+(`smoother_stationary_detector_`, `smoother_vehicle_model_`), so the per-IMU
+corrections (orientation / flat-ground / NHC / ZUPT / ZIHR / bias-observability
+gating) are applied independently of the main filter. This keeps the two forward
+runs from sharing stateful detector state while making their dynamics identical.
+On the same Applanix segment, feeding these corrections reduced the
+filter-vs-smoothed trajectory gap from ~29 m to ~15 m; the remaining gap comes
+from the smoother fusing measurements at node boundaries (every `node_subsample`
+IMU steps) instead of at each sensor timestamp as the replay engine does, and is
+not an accuracy problem: the smoothed track stays ~8x closer to the reference.
+
+## Limitations
+
+- The smoother is an offline oracle; it is not used for control. Its forward
+  track applies the same per-IMU corrections (via private detector / vehicle
+  model instances) and the same measurements as the filter, so the only
+  difference is the backward smoothing pass.
+- Subsample composition is a first-order composition of the discrete models;
+  large subsample factors reduce the effective node rate and slightly coarsen the
+  smoothing timeline.
+- Measurements are applied at node boundaries, so a measurement between nodes is
+  fused at the next node (up to `node_subsample / imu_rate` later). This is the
+  main source of the remaining filter-vs-smoothed gap; it does not hurt
+  accuracy.
+- Out-of-order delayed measurements are rejected by the smoother (the live
+  pipeline keeps `EskfReplay` for those).

--- a/kalman_filter_localization_core/CMakeLists.txt
+++ b/kalman_filter_localization_core/CMakeLists.txt
@@ -39,6 +39,7 @@ if(BUILD_TESTING)
   ament_add_gtest(test_odometry_core test/test_odometry_core.cpp)
   ament_add_gtest(test_vehicle_observability test/test_vehicle_observability.cpp)
   ament_add_gtest(test_sensor_fault_monitor test/test_sensor_fault_monitor.cpp)
+  ament_add_gtest(test_fixed_lag_smoother test/test_fixed_lag_smoother.cpp)
   # ament_add_gtest uses the plain target_link_libraries() signature internally,
   # so keep using the plain signature here too (CMake forbids mixing styles).
   target_link_libraries(test_ekf_core ${PROJECT_NAME})
@@ -47,6 +48,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_odometry_core ${PROJECT_NAME})
   target_link_libraries(test_vehicle_observability ${PROJECT_NAME})
   target_link_libraries(test_sensor_fault_monitor ${PROJECT_NAME})
+  target_link_libraries(test_fixed_lag_smoother ${PROJECT_NAME})
 endif()
 
 ament_export_dependencies(eigen3_cmake_module)

--- a/kalman_filter_localization_core/include/kalman_filter_localization/core/ekf_estimator.hpp
+++ b/kalman_filter_localization_core/include/kalman_filter_localization/core/ekf_estimator.hpp
@@ -618,8 +618,13 @@ public:
     if (!checkNumericalInvariants()) {
       x_ = state_before;
       P_ = covariance_before;
+      has_last_discrete_model_ = false;
       return PredictionUpdateStatus::kNumericalFailure;
     }
+    last_discrete_model_.transition = F;
+    last_discrete_model_.process_covariance = discrete_process_noise;
+    last_prediction_dt_ = dt_imu;
+    has_last_discrete_model_ = true;
     return PredictionUpdateStatus::kUpdated;
   }
 
@@ -1425,6 +1430,29 @@ public:
     return num_state_;
   }
 
+  // Returns the discrete transition and process-covariance matrices actually used
+  // by the most recent successful predictionUpdateDt call. This lets downstream
+  // consumers (e.g. an RTS smoother) reconstruct the linearized error dynamics
+  // consistently with the running filter.
+  bool getLastDiscreteModel(DiscreteErrorModel & model) const
+  {
+    if (!has_last_discrete_model_) {
+      return false;
+    }
+    model = last_discrete_model_;
+    return true;
+  }
+
+  double getLastPredictionDt() const
+  {
+    return last_prediction_dt_;
+  }
+
+  bool hasLastDiscreteModel() const
+  {
+    return has_last_discrete_model_;
+  }
+
 private:
   static const int num_state_{16};
   static const int num_error_state_{15};
@@ -1652,6 +1680,9 @@ private:
 
   double previous_time_imu_;
   bool has_previous_time_imu_;
+  DiscreteErrorModel last_discrete_model_{};
+  double last_prediction_dt_{0.0};
+  bool has_last_discrete_model_{false};
   double var_imu_w_;
   double var_imu_acc_;
   double var_imu_gyro_bias_;

--- a/kalman_filter_localization_core/include/kalman_filter_localization/core/fixed_lag_smoother.hpp
+++ b/kalman_filter_localization_core/include/kalman_filter_localization/core/fixed_lag_smoother.hpp
@@ -1,0 +1,645 @@
+// Copyright (c) 2026, Ryohei Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef KALMAN_FILTER_LOCALIZATION__CORE__FIXED_LAG_SMOOTHER_HPP_
+#define KALMAN_FILTER_LOCALIZATION__CORE__FIXED_LAG_SMOOTHER_HPP_
+
+#include <Eigen/Core>
+#include <Eigen/Cholesky>
+#include <Eigen/Geometry>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <limits>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include <kalman_filter_localization/core/ekf_estimator.hpp>
+
+namespace kalman_filter_localization
+{
+namespace core
+{
+
+// Offline/optional fixed-lag Rauch-Tung-Striebel (RTS) smoother over the ESKF.
+//
+// The smoother records, for every IMU prediction step, the nominal state right
+// after propagation (before any measurement update), the post-update state and
+// covariance, and the discrete transition / process-covariance pair (Phi, Qd)
+// that the filter actually used (see EKFEstimator::getLastDiscreteModel). A
+// backward RTS pass then re-conditions every stored node on all measurements up
+// to the latest one, which is exactly the "offline oracle" the EKF error
+// analysis in plan.md Phase 7 asks for.
+//
+// Two operation modes:
+//  - Fixed-lag (lag_sec > 0): the retained window is bounded in time. When the
+//    oldest node falls out of the lag window it is smoothed against the current
+//    window, emitted through popSmoothed(), and dropped. Memory is O(lag).
+//  - Batch (lag_sec <= 0): all nodes are kept until finalize(), which emits the
+//    whole smoothed trajectory in one backward pass.
+//
+// Measurements are expected in non-decreasing sensor time order (in-order, as an
+// offline bag replay would produce). Out-of-window, duplicate, or reverse-stamped
+// events are counted and rejected; delayed out-of-order rewind is the job of
+// EskfReplay in the live pipeline, not of this oracle.
+class FixedLagSmoother
+{
+public:
+  using MeasurementFunction =
+    std::function<EKFEstimator::ObservationUpdateStatus(EKFEstimator &)>;
+
+  enum class Status : std::uint8_t
+  {
+    kInitialized = 0,
+    kApplied,
+    kEmitted,
+    kQueuedFuture,
+    kTooOld,
+    kFuture,
+    kDuplicate,
+    kReverseImu,
+    kInvalidInput,
+    kUpdateRejected,
+    kNumericalFailure,
+  };
+
+  struct Node
+  {
+    double time{std::numeric_limits<double>::quiet_NaN()};
+    EKFEstimator::State predicted_state{};
+    EKFEstimator::ErrorStateMatrix predicted_covariance{
+      EKFEstimator::ErrorStateMatrix::Identity()};
+    EKFEstimator::State state{};
+    EKFEstimator::ErrorStateMatrix covariance{
+      EKFEstimator::ErrorStateMatrix::Identity()};
+    EKFEstimator::ErrorStateMatrix transition{
+      EKFEstimator::ErrorStateMatrix::Identity()};
+    EKFEstimator::ErrorStateMatrix process_covariance{
+      EKFEstimator::ErrorStateMatrix::Zero()};
+  };
+
+  struct SmoothedNode
+  {
+    double time{std::numeric_limits<double>::quiet_NaN()};
+    EKFEstimator::State state{};
+    EKFEstimator::ErrorStateMatrix covariance{
+      EKFEstimator::ErrorStateMatrix::Identity()};
+  };
+
+  struct Counters
+  {
+    std::uint64_t imu_samples{0};
+    std::uint64_t measurements_applied{0};
+    std::uint64_t smoothed_emitted{0};
+    std::uint64_t too_old{0};
+    std::uint64_t future{0};
+    std::uint64_t duplicate{0};
+    std::uint64_t reverse_imu{0};
+    std::uint64_t invalid_input{0};
+    std::uint64_t update_rejected{0};
+    std::uint64_t numerical_failure{0};
+  };
+
+  explicit FixedLagSmoother(
+    EKFEstimator & estimator, const double lag_sec,
+    const double max_future_wait_sec = 0.5, const std::size_t node_subsample = 1)
+  : estimator_(estimator), lag_sec_(lag_sec), max_future_wait_sec_(max_future_wait_sec),
+    node_subsample_(std::max<std::size_t>(node_subsample, 1U))
+  {
+    if (!(max_future_wait_sec_ >= 0.0) || !std::isfinite(max_future_wait_sec_)) {
+      max_future_wait_sec_ = 0.5;
+    }
+  }
+
+  bool setLagDuration(const double lag_sec)
+  {
+    if (!std::isfinite(lag_sec)) {
+      return false;
+    }
+    lag_sec_ = lag_sec;
+    pruneToLag();
+    return true;
+  }
+
+  // Records one smoother node every `subsample`-th IMU sample, composing the
+  // per-step discrete transition / process covariance over the interval. This
+  // shrinks the RTS window (and thus the per-step backward-pass cost) by the
+  // same factor so the smoother can run in real time at IMU rate.
+  bool setNodeSubsample(const std::size_t subsample)
+  {
+    if (subsample == 0U) {
+      return false;
+    }
+    node_subsample_ = subsample;
+    return true;
+  }
+
+  std::size_t nodeSubsample() const {return node_subsample_;}
+
+  double lagDuration() const {return lag_sec_;}
+
+  void reset()
+  {
+    nodes_.clear();
+    measurements_.clear();
+    pending_measurements_.clear();
+    measurement_ids_.clear();
+    emitted_.clear();
+    last_imu_time_ = std::numeric_limits<double>::quiet_NaN();
+    subsample_counter_ = 0U;
+    accumulated_transition_ = EKFEstimator::ErrorStateMatrix::Identity();
+    accumulated_process_covariance_ = EKFEstimator::ErrorStateMatrix::Zero();
+    counters_ = Counters{};
+  }
+
+  // Feeds one IMU sample. A `correction` (e.g. wheel/NHC) is applied right after
+  // the prediction, before any queued measurement, mirroring EskfReplay.
+  Status addImu(
+    const double sensor_time, const Eigen::Vector3d & gyro,
+    const Eigen::Vector3d & acceleration, MeasurementFunction correction = MeasurementFunction{})
+  {
+    if (!std::isfinite(sensor_time) || !gyro.allFinite() || !acceleration.allFinite()) {
+      ++counters_.invalid_input;
+      return Status::kInvalidInput;
+    }
+    if (nodes_.empty()) {
+      if (!estimator_.primeImuMeasurement(gyro, acceleration)) {
+        ++counters_.invalid_input;
+        return Status::kInvalidInput;
+      }
+      last_imu_time_ = sensor_time;
+      subsample_counter_ = 0U;
+      accumulated_transition_ = EKFEstimator::ErrorStateMatrix::Identity();
+      accumulated_process_covariance_ = EKFEstimator::ErrorStateMatrix::Zero();
+      if (correction && correction(estimator_) != EKFEstimator::ObservationUpdateStatus::kUpdated) {
+        ++counters_.update_rejected;
+        return Status::kUpdateRejected;
+      }
+      // Apply any measurements that arrived before the first IMU so node0's
+      // covariance reflects the early updates. Otherwise node0 keeps the large
+      // initial covariance while node1's predicted covariance is already small,
+      // which blows up the RTS smoothing gain (P0 * Phi^T * inv(P1|0)).
+      if (!applyPendingMeasurements(sensor_time)) {
+        ++counters_.numerical_failure;
+        return Status::kNumericalFailure;
+      }
+      Node node;
+      node.time = sensor_time;
+      node.predicted_state = estimator_.getState();
+      node.predicted_covariance = estimator_.getCovariance();
+      node.state = estimator_.getState();
+      node.covariance = estimator_.getCovariance();
+      node.transition = EKFEstimator::ErrorStateMatrix::Identity();
+      node.process_covariance = EKFEstimator::ErrorStateMatrix::Zero();
+      nodes_.push_back(std::move(node));
+      ++counters_.imu_samples;
+      return Status::kInitialized;
+    }
+    if (!(sensor_time > last_imu_time_)) {
+      ++counters_.reverse_imu;
+      return Status::kReverseImu;
+    }
+    const double dt = sensor_time - last_imu_time_;
+    last_imu_time_ = sensor_time;
+    const auto prediction_status = estimator_.predictionUpdateDt(dt, gyro, acceleration);
+    if (prediction_status != EKFEstimator::PredictionUpdateStatus::kUpdated) {
+      if (prediction_status == EKFEstimator::PredictionUpdateStatus::kNumericalFailure) {
+        ++counters_.numerical_failure;
+        return Status::kNumericalFailure;
+      }
+      ++counters_.invalid_input;
+      return Status::kInvalidInput;
+    }
+    EKFEstimator::DiscreteErrorModel model;
+    if (!estimator_.getLastDiscreteModel(model)) {
+      ++counters_.numerical_failure;
+      return Status::kNumericalFailure;
+    }
+    // Compose the discrete transition / process covariance over the current
+    // subsample interval so a single RTS step covers several IMU steps.
+    accumulated_transition_ = model.transition * accumulated_transition_;
+    accumulated_process_covariance_ =
+      model.transition * accumulated_process_covariance_ * model.transition.transpose() +
+      model.process_covariance;
+    ++subsample_counter_;
+    if (subsample_counter_ < node_subsample_) {
+      ++counters_.imu_samples;
+      return Status::kApplied;
+    }
+    subsample_counter_ = 0U;
+    if (correction && correction(estimator_) != EKFEstimator::ObservationUpdateStatus::kUpdated) {
+      estimator_.restoreSnapshot(previousSnapshot());
+      ++counters_.update_rejected;
+      return Status::kUpdateRejected;
+    }
+    Node node;
+    node.time = sensor_time;
+    node.predicted_state = estimator_.getState();
+    node.predicted_covariance = estimator_.getCovariance();
+    node.transition = accumulated_transition_;
+    node.process_covariance = accumulated_process_covariance_;
+    accumulated_transition_ = EKFEstimator::ErrorStateMatrix::Identity();
+    accumulated_process_covariance_ = EKFEstimator::ErrorStateMatrix::Zero();
+    if (!applyPendingMeasurements(sensor_time)) {
+      estimator_.restoreSnapshot(previousSnapshot());
+      ++counters_.numerical_failure;
+      return Status::kNumericalFailure;
+    }
+    node.state = estimator_.getState();
+    node.covariance = estimator_.getCovariance();
+    nodes_.push_back(std::move(node));
+    ++counters_.imu_samples;
+    pruneToLag();
+    return emittedWasAppended() ? Status::kEmitted : Status::kApplied;
+  }
+
+  // Feeds one measurement whose update function is applied to the estimator at
+  // its sensor time. In-order measurements whose time is at most the latest node
+  // time are applied immediately; later ones are queued up to max_future_wait.
+  Status applyMeasurement(
+    const double sensor_time, const std::uint64_t measurement_id,
+    MeasurementFunction update)
+  {
+    if (!std::isfinite(sensor_time) || !update) {
+      ++counters_.invalid_input;
+      return Status::kInvalidInput;
+    }
+    if (measurement_ids_.count(measurement_id) != 0U) {
+      ++counters_.duplicate;
+      return Status::kDuplicate;
+    }
+    if (nodes_.empty()) {
+      MeasurementEvent event{sensor_time, measurement_id, std::move(update)};
+      const auto position = std::lower_bound(
+        pending_measurements_.begin(), pending_measurements_.end(), event,
+        [](const MeasurementEvent & left, const MeasurementEvent & right) {
+          return std::tie(left.time, left.id) < std::tie(right.time, right.id);
+        });
+      pending_measurements_.insert(position, std::move(event));
+      measurement_ids_.insert(measurement_id);
+      ++counters_.future;
+      return Status::kQueuedFuture;
+    }
+    constexpr double kTimeTolerance = 1.0e-12;
+    if (sensor_time < nodes_.front().time - kTimeTolerance) {
+      ++counters_.too_old;
+      return Status::kTooOld;
+    }
+    if (sensor_time > last_imu_time_ + kTimeTolerance) {
+      if (sensor_time - last_imu_time_ <= max_future_wait_sec_) {
+        MeasurementEvent event{sensor_time, measurement_id, std::move(update)};
+        const auto position = std::lower_bound(
+          pending_measurements_.begin(), pending_measurements_.end(), event,
+          [](const MeasurementEvent & left, const MeasurementEvent & right) {
+            return std::tie(left.time, left.id) < std::tie(right.time, right.id);
+          });
+        pending_measurements_.insert(position, std::move(event));
+        measurement_ids_.insert(measurement_id);
+        ++counters_.future;
+        return Status::kQueuedFuture;
+      }
+      ++counters_.future;
+      return Status::kFuture;
+    }
+    if (std::fabs(sensor_time - nodes_.back().time) <= kTimeTolerance) {
+      // Measurement exactly at the latest node boundary: apply now so the node
+      // records the post-measurement state, keeping the RTS relationship
+      // predicted (pure propagation) -> state (after measurements).
+      if (!applyEventNow(update)) {
+        ++counters_.update_rejected;
+        return Status::kUpdateRejected;
+      }
+      measurement_ids_.insert(measurement_id);
+      ++counters_.measurements_applied;
+      nodes_.back().state = estimator_.getState();
+      nodes_.back().covariance = estimator_.getCovariance();
+      return Status::kApplied;
+    }
+    // Measurement between node boundaries: defer to the next node so the
+    // predicted state of that node stays measurement-free (required by RTS).
+    {
+      MeasurementEvent event{sensor_time, measurement_id, std::move(update)};
+      const auto position = std::lower_bound(
+        pending_measurements_.begin(), pending_measurements_.end(), event,
+        [](const MeasurementEvent & left, const MeasurementEvent & right) {
+          return std::tie(left.time, left.id) < std::tie(right.time, right.id);
+        });
+      pending_measurements_.insert(position, std::move(event));
+      measurement_ids_.insert(measurement_id);
+      return Status::kQueuedFuture;
+    }
+  }
+
+  // After all data has been fed, emits the smoothed estimate for every retained
+  // node (batch mode) in time order and clears the history. Returns how many
+  // nodes were emitted.
+  std::size_t finalize()
+  {
+    if (nodes_.size() < 2U) {
+      std::size_t count = nodes_.size();
+      for (const auto & node : nodes_) {
+        emitted_.push_back({node.time, node.state, node.covariance});
+      }
+      nodes_.clear();
+      counters_.smoothed_emitted += count;
+      return count;
+    }
+    const std::vector<SmoothedNode> smoothed = runBackwardPass();
+    emitted_.insert(emitted_.end(), smoothed.begin(), smoothed.end());
+    counters_.smoothed_emitted += smoothed.size();
+    const std::size_t count = smoothed.size();
+    nodes_.clear();
+    measurements_.clear();
+    pending_measurements_.clear();
+    measurement_ids_.clear();
+    return count;
+  }
+
+  // Batch access: returns the full smoothed trajectory without clearing state.
+  std::vector<SmoothedNode> smoothAll() const
+  {
+    if (nodes_.size() < 2U) {
+      std::vector<SmoothedNode> result;
+      result.reserve(nodes_.size());
+      for (const auto & node : nodes_) {
+        result.push_back({node.time, node.state, node.covariance});
+      }
+      return result;
+    }
+    return runBackwardPass();
+  }
+
+  bool popSmoothed(SmoothedNode & out)
+  {
+    if (emitted_.empty()) {
+      return false;
+    }
+    out = emitted_.front();
+    emitted_.erase(emitted_.begin());
+    return true;
+  }
+
+  std::size_t smoothedCount() const {return emitted_.size();}
+
+  double oldestTime() const
+  {
+    return nodes_.empty() ? std::numeric_limits<double>::quiet_NaN() :
+           nodes_.front().time;
+  }
+
+  double latestTime() const
+  {
+    return nodes_.empty() ? std::numeric_limits<double>::quiet_NaN() :
+           nodes_.back().time;
+  }
+
+  std::size_t nodeCount() const {return nodes_.size();}
+  const std::vector<Node> & nodes() const {return nodes_;}
+  const Counters & counters() const {return counters_;}
+
+  std::size_t estimatedHistoryMemoryBytes() const
+  {
+    return nodes_.size() * sizeof(Node) +
+           measurements_.size() * sizeof(MeasurementEvent) +
+           pending_measurements_.size() * sizeof(MeasurementEvent);
+  }
+
+private:
+  struct MeasurementEvent
+  {
+    double time;
+    std::uint64_t id;
+    MeasurementFunction update;
+  };
+
+  static constexpr int kDx = 0;
+  static constexpr int kDv = 3;
+  static constexpr int kDth = 6;
+  static constexpr int kDbg = 9;
+  static constexpr int kDba = 12;
+
+  EKFEstimator::Snapshot previousSnapshot() const
+  {
+    return estimator_.getSnapshot();
+  }
+
+  static Eigen::Vector3d logSO3(const Eigen::Quaterniond & q)
+  {
+    Eigen::Quaterniond normalized = q.normalized();
+    if (normalized.w() < 0.0) {
+      normalized.coeffs() *= -1.0;
+    }
+    const Eigen::AngleAxisd axis_angle(normalized);
+    const double angle = axis_angle.angle();
+    if (angle < 1.0e-9) {
+      return Eigen::Vector3d::Zero();
+    }
+    return axis_angle.axis() * angle;
+  }
+
+  static EKFEstimator::ErrorStateVector stateDifference(
+    const EKFEstimator::State & a, const EKFEstimator::State & b)
+  {
+    EKFEstimator::ErrorStateVector delta =
+      EKFEstimator::ErrorStateVector::Zero();
+    delta.template segment<3>(kDx) =
+      a.position - b.position;
+    delta.template segment<3>(kDv) =
+      a.velocity - b.velocity;
+    delta.template segment<3>(kDth) =
+      logSO3(b.orientation.conjugate() * a.orientation);
+    delta.template segment<3>(kDbg) =
+      a.gyro_bias - b.gyro_bias;
+    delta.template segment<3>(kDba) =
+      a.accel_bias - b.accel_bias;
+    return delta;
+  }
+
+  static EKFEstimator::State injectState(
+    const EKFEstimator::State & state,
+    const EKFEstimator::ErrorStateVector & delta)
+  {
+    EKFEstimator::State result = state;
+    result.position += delta.template segment<3>(kDx);
+    result.velocity += delta.template segment<3>(kDv);
+    const Eigen::Vector3d dtheta =
+      delta.template segment<3>(kDth);
+    const double norm = dtheta.norm();
+    Eigen::Quaterniond dq;
+    if (norm < 1.0e-12) {
+      dq = Eigen::Quaterniond(1.0, 0.5 * dtheta.x(), 0.5 * dtheta.y(), 0.5 * dtheta.z());
+      dq.normalize();
+    } else {
+      dq = Eigen::Quaterniond(
+        std::cos(norm / 2.0),
+        std::sin(norm / 2.0) * dtheta.x() / norm,
+        std::sin(norm / 2.0) * dtheta.y() / norm,
+        std::sin(norm / 2.0) * dtheta.z() / norm);
+    }
+    result.orientation = (result.orientation.normalized() * dq).normalized();
+    result.gyro_bias += delta.template segment<3>(kDbg);
+    result.accel_bias += delta.template segment<3>(kDba);
+    return result;
+  }
+
+  std::vector<SmoothedNode> runBackwardPass() const
+  {
+    const std::size_t n = nodes_.size();
+    std::vector<SmoothedNode> result(n);
+    result[n - 1].time = nodes_[n - 1].time;
+    result[n - 1].state = nodes_[n - 1].state;
+    result[n - 1].covariance = nodes_[n - 1].covariance;
+    for (std::size_t k = n - 1; k-- > 0U; ) {
+      const Node & node = nodes_[k];
+      const Node & next = nodes_[k + 1];
+      const Eigen::Matrix<double, EKFEstimator::kErrorStateSize, 1> smoothed_delta =
+        stateDifference(result[k + 1].state, next.predicted_state);
+      const Eigen::Matrix<double, EKFEstimator::kErrorStateSize, EKFEstimator::kErrorStateSize>
+      covariance_times_transition = node.covariance * next.transition.transpose();
+      const Eigen::LDLT<EKFEstimator::ErrorStateMatrix> decomposition(
+        0.5 * (next.predicted_covariance + next.predicted_covariance.transpose()));
+      if (decomposition.info() != Eigen::Success || !decomposition.isPositive()) {
+        result[k].time = node.time;
+        result[k].state = node.state;
+        result[k].covariance = node.covariance;
+        continue;
+      }
+      const Eigen::Matrix<double, EKFEstimator::kErrorStateSize, EKFEstimator::kErrorStateSize>
+      gain = decomposition.solve(covariance_times_transition.transpose()).transpose();
+      const Eigen::Matrix<double, EKFEstimator::kErrorStateSize, 1> error_update =
+        gain * smoothed_delta;
+      if (!error_update.allFinite()) {
+        result[k].time = node.time;
+        result[k].state = node.state;
+        result[k].covariance = node.covariance;
+        continue;
+      }
+      result[k].time = node.time;
+      result[k].state = injectState(node.state, error_update);
+      EKFEstimator::ErrorStateMatrix updated =
+        node.covariance + gain * (result[k + 1].covariance - next.predicted_covariance) *
+        gain.transpose();
+      updated = 0.5 * (updated + updated.transpose());
+      if (!updated.allFinite()) {
+        result[k].covariance = node.covariance;
+      } else {
+        result[k].covariance = updated;
+      }
+    }
+    return result;
+  }
+
+  bool applyEventNow(const MeasurementFunction & update)
+  {
+    const auto status = update(estimator_);
+    return status == EKFEstimator::ObservationUpdateStatus::kUpdated;
+  }
+
+  bool applyPendingMeasurements(const double filter_time)
+  {
+    while (!pending_measurements_.empty() &&
+      pending_measurements_.front().time <= filter_time + 1.0e-12)
+    {
+      MeasurementEvent event = std::move(pending_measurements_.front());
+      pending_measurements_.erase(pending_measurements_.begin());
+      if (!applyEventNow(event.update)) {
+        measurement_ids_.erase(event.id);
+        return false;
+      }
+      measurement_ids_.erase(event.id);
+      ++counters_.measurements_applied;
+    }
+    return true;
+  }
+
+  void pruneToLag()
+  {
+    if (!(lag_sec_ > 0.0) || nodes_.size() < 2U) {
+      return;
+    }
+    bool emitted_any = false;
+    while (nodes_.size() > 1U &&
+      nodes_.back().time - nodes_.front().time > lag_sec_)
+    {
+      const std::vector<SmoothedNode> smoothed = runBackwardPass();
+      emitted_.push_back(smoothed.front());
+      ++counters_.smoothed_emitted;
+      const double oldest = nodes_.front().time;
+      nodes_.erase(nodes_.begin());
+      measurements_.erase(
+        std::remove_if(
+          measurements_.begin(), measurements_.end(),
+          [this, oldest](const MeasurementEvent & event) {
+            if (event.time <= oldest) {
+              measurement_ids_.erase(event.id);
+              return true;
+            }
+            return false;
+          }),
+        measurements_.end());
+      emitted_any = true;
+    }
+    last_emitted_ = emitted_any;
+  }
+
+  bool emittedWasAppended() const
+  {
+    return last_emitted_;
+  }
+
+  EKFEstimator & estimator_;
+  double lag_sec_;
+  double max_future_wait_sec_;
+  std::size_t node_subsample_{1};
+  double last_imu_time_{std::numeric_limits<double>::quiet_NaN()};
+  std::size_t subsample_counter_{0};
+  EKFEstimator::ErrorStateMatrix accumulated_transition_{
+    EKFEstimator::ErrorStateMatrix::Identity()};
+  EKFEstimator::ErrorStateMatrix accumulated_process_covariance_{
+    EKFEstimator::ErrorStateMatrix::Zero()};
+  bool last_emitted_{false};
+  std::vector<Node> nodes_;
+  std::vector<MeasurementEvent> measurements_;
+  std::vector<MeasurementEvent> pending_measurements_;
+  std::unordered_set<std::uint64_t> measurement_ids_;
+  std::vector<SmoothedNode> emitted_;
+  Counters counters_{};
+};
+
+}  // namespace core
+}  // namespace kalman_filter_localization
+
+#endif  // KALMAN_FILTER_LOCALIZATION__CORE__FIXED_LAG_SMOOTHER_HPP_

--- a/kalman_filter_localization_core/test/test_fixed_lag_smoother.cpp
+++ b/kalman_filter_localization_core/test/test_fixed_lag_smoother.cpp
@@ -1,0 +1,347 @@
+// Copyright (c) 2026, Ryohei Sasaki
+// All rights reserved.
+//
+// Software License Agreement (BSD License 2.0)
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above
+//    copyright notice, this list of conditions and the following
+//    disclaimer in the documentation and/or other materials provided
+//    with the distribution.
+//  * Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+// FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+// BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+#include <vector>
+
+#include <kalman_filter_localization/core/fixed_lag_smoother.hpp>
+
+namespace
+{
+using kalman_filter_localization::core::EKFEstimator;
+using kalman_filter_localization::core::FixedLagSmoother;
+
+void configure(EKFEstimator & estimator)
+{
+  estimator.setPropagationModel(EKFEstimator::PropagationModel::kExact);
+  estimator.setVarImuAcc(0.5);
+  estimator.setVarImuGyro(0.01);
+  estimator.setVarImuGyroBias(1.0e-6);
+  estimator.setVarImuAccBias(1.0e-5);
+  estimator.setTauGyroBias(300.0);
+  estimator.setTauAccBias(300.0);
+  estimator.setMaxPredictionDtSec(2.0);
+}
+
+EKFEstimator::State makeState(const Eigen::Vector3d & position)
+{
+  EKFEstimator::State state;
+  state.position = position;
+  state.velocity = Eigen::Vector3d(1.0, 0.0, 0.0);
+  state.orientation = Eigen::Quaterniond::Identity();
+  state.gyro_bias = Eigen::Vector3d::Zero();
+  state.accel_bias = Eigen::Vector3d::Zero();
+  return state;
+}
+
+FixedLagSmoother::MeasurementFunction positionUpdate(
+  const Eigen::Vector3d & position, const Eigen::Vector3d & variance)
+{
+  return [position, variance](EKFEstimator & estimator) {
+           return estimator.observationUpdateWithStatus(position, variance);
+         };
+}
+}  // namespace
+
+// The filter alone should see a strictly larger covariance than the smoother for
+// the same node. In a straight-line run with only position measurements, the RTS
+// backward pass re-conditions past nodes and must never increase their trace.
+TEST(FixedLagSmoother, SmoothedCovarianceIsNoLargerThanFilterCovariance)
+{
+  EKFEstimator estimator;
+  configure(estimator);
+  FixedLagSmoother smoother(estimator, -1.0);
+
+  const Eigen::Vector3d variance(0.1, 0.1, 0.1);
+  for (int i = 0; i <= 40; ++i) {
+    const double t = 0.1 * i;
+    const Eigen::Vector3d position(1.0 * t, 0.0, 0.0);
+    ASSERT_EQ(
+      smoother.addImu(t, Eigen::Vector3d::Zero(), Eigen::Vector3d(0.0, 0.0, 9.80665)),
+      i == 0 ? FixedLagSmoother::Status::kInitialized : FixedLagSmoother::Status::kApplied);
+    if (i > 0 && i % 10 == 0) {
+      ASSERT_EQ(
+        smoother.applyMeasurement(
+          t, static_cast<std::uint64_t>(i),
+          positionUpdate(position, variance)),
+        FixedLagSmoother::Status::kApplied);
+    }
+  }
+
+  const auto smoothed = smoother.smoothAll();
+  ASSERT_EQ(smoothed.size(), smoother.nodeCount());
+  const auto & nodes = smoother.nodes();
+  for (std::size_t i = 0; i < nodes.size(); ++i) {
+    const double filter_trace = nodes[i].covariance.trace();
+    const double smoothed_trace = smoothed[i].covariance.trace();
+    EXPECT_LE(smoothed_trace, filter_trace + 1.0e-9)
+      << "node " << i << " filter=" << filter_trace << " smoothed=" << smoothed_trace;
+  }
+}
+
+// A fixed-lag window that covers the entire dataset must reproduce the batch
+// smoother output exactly (identical states and covariances, time-aligned).
+TEST(FixedLagSmoother, InfiniteLagMatchesBatch)
+{
+  EKFEstimator estimator;
+  configure(estimator);
+  FixedLagSmoother smoother(estimator, -1.0);
+
+  const Eigen::Vector3d variance(0.2, 0.2, 0.2);
+  for (int i = 0; i <= 50; ++i) {
+    const double t = 0.1 * i;
+    const Eigen::Vector3d position(1.0 * t, 0.5 * t, 0.0);
+    ASSERT_EQ(
+      smoother.addImu(t, Eigen::Vector3d::Zero(), Eigen::Vector3d(0.0, 0.0, 9.80665)),
+      i == 0 ? FixedLagSmoother::Status::kInitialized : FixedLagSmoother::Status::kApplied);
+    if (i > 0 && i % 5 == 0) {
+      ASSERT_EQ(
+        smoother.applyMeasurement(
+          t, static_cast<std::uint64_t>(i),
+          positionUpdate(position, variance)),
+        FixedLagSmoother::Status::kApplied);
+    }
+  }
+  const std::vector<FixedLagSmoother::SmoothedNode> batch = smoother.smoothAll();
+  ASSERT_FALSE(batch.empty());
+
+  // Now rerun with a huge lag: nothing should be emitted before finalize().
+  EKFEstimator estimator2;
+  configure(estimator2);
+  FixedLagSmoother fixed(estimator2, 1.0e6);
+  for (int i = 0; i <= 50; ++i) {
+    const double t = 0.1 * i;
+    const Eigen::Vector3d position(1.0 * t, 0.5 * t, 0.0);
+    fixed.addImu(t, Eigen::Vector3d::Zero(), Eigen::Vector3d(0.0, 0.0, 9.80665));
+    if (i > 0 && i % 5 == 0) {
+      fixed.applyMeasurement(t, static_cast<std::uint64_t>(i), positionUpdate(position, variance));
+    }
+  }
+  EXPECT_EQ(fixed.smoothedCount(), 0U);
+  ASSERT_EQ(fixed.finalize(), batch.size());
+  std::vector<FixedLagSmoother::SmoothedNode> final_nodes;
+  FixedLagSmoother::SmoothedNode out;
+  while (fixed.popSmoothed(out)) {
+    final_nodes.push_back(out);
+  }
+  ASSERT_EQ(final_nodes.size(), batch.size());
+  for (std::size_t i = 0; i < batch.size(); ++i) {
+    EXPECT_DOUBLE_EQ(final_nodes[i].time, batch[i].time);
+    EXPECT_TRUE(final_nodes[i].state.position.isApprox(batch[i].state.position, 1.0e-9))
+      << "node " << i;
+    EXPECT_TRUE(final_nodes[i].covariance.isApprox(batch[i].covariance, 1.0e-9))
+      << "node " << i;
+  }
+}
+
+// With real measurements, smoothing must reduce position error against ground
+// truth in the aggregate: the batch oracle is at least as good as the filter.
+TEST(FixedLagSmoother, SmootherReducesErrorOnNoisyMeasurements)
+{
+  EKFEstimator estimator;
+  configure(estimator);
+  FixedLagSmoother smoother(estimator, -1.0);
+
+  std::mt19937 generator(42);
+  std::normal_distribution<double> noise(0.0, 0.3);
+
+  const double measurement_noise_variance = 0.3 * 0.3;
+  for (int i = 0; i <= 60; ++i) {
+    const double t = 0.1 * i;
+    const Eigen::Vector3d true_position(1.0 * t, 0.0, 0.0);
+    ASSERT_EQ(
+      smoother.addImu(t, Eigen::Vector3d::Zero(), Eigen::Vector3d(0.0, 0.0, 9.80665)),
+      i == 0 ? FixedLagSmoother::Status::kInitialized : FixedLagSmoother::Status::kApplied);
+    if (i > 0 && i % 3 == 0) {
+      const Eigen::Vector3d measured = true_position +
+        Eigen::Vector3d(noise(generator), noise(generator), noise(generator));
+      ASSERT_EQ(
+        smoother.applyMeasurement(
+          t, static_cast<std::uint64_t>(i),
+          positionUpdate(measured, Eigen::Vector3d::Constant(measurement_noise_variance))),
+        FixedLagSmoother::Status::kApplied);
+    }
+  }
+
+  const auto smoothed = smoother.smoothAll();
+  const auto & nodes = smoother.nodes();
+  ASSERT_EQ(smoothed.size(), nodes.size());
+
+  double filter_error_sum = 0.0;
+  double smoothed_error_sum = 0.0;
+  for (std::size_t i = 0; i < nodes.size(); ++i) {
+    const double t = nodes[i].time;
+    const Eigen::Vector3d true_position(1.0 * t, 0.0, 0.0);
+    filter_error_sum += (nodes[i].state.position - true_position).norm();
+    smoothed_error_sum += (smoothed[i].state.position - true_position).norm();
+  }
+  EXPECT_LT(smoothed_error_sum, filter_error_sum);
+}
+
+// A fixed-lag window emits the oldest node once it leaves the window; emissions
+// are in time order and each emitted covariance is consistent with the batch one
+// for nodes that have enough future data (here the window covers everything, so
+// emitted nodes equal the batch nodes they correspond to).
+TEST(FixedLagSmoother, FixedLagEmitsInTimeOrder)
+{
+  EKFEstimator estimator;
+  configure(estimator);
+  FixedLagSmoother smoother(estimator, 1.0);
+
+  const Eigen::Vector3d variance(0.2, 0.2, 0.2);
+  for (int i = 0; i <= 40; ++i) {
+    const double t = 0.1 * i;
+    const Eigen::Vector3d position(1.0 * t, 0.0, 0.0);
+    const auto status = smoother.addImu(
+      t, Eigen::Vector3d::Zero(), Eigen::Vector3d(0.0, 0.0, 9.80665));
+    ASSERT_TRUE(
+      status == FixedLagSmoother::Status::kInitialized ||
+      status == FixedLagSmoother::Status::kApplied ||
+      status == FixedLagSmoother::Status::kEmitted);
+    if (i > 0 && i % 5 == 0) {
+      ASSERT_EQ(
+        smoother.applyMeasurement(
+          t, static_cast<std::uint64_t>(i),
+          positionUpdate(position, variance)),
+        FixedLagSmoother::Status::kApplied);
+    }
+  }
+  EXPECT_GT(smoother.smoothedCount(), 0U);
+  double previous_time = -1.0;
+  FixedLagSmoother::SmoothedNode out;
+  while (smoother.popSmoothed(out)) {
+    EXPECT_GT(out.time, previous_time);
+    previous_time = out.time;
+  }
+}
+
+// Reverse-stamped IMU and duplicate measurements must be rejected and counted.
+TEST(FixedLagSmoother, RejectsReverseImuAndDuplicateMeasurements)
+{
+  EKFEstimator estimator;
+  configure(estimator);
+  FixedLagSmoother smoother(estimator, -1.0);
+
+  ASSERT_EQ(
+    smoother.addImu(0.0, Eigen::Vector3d::Zero(), Eigen::Vector3d(0.0, 0.0, 9.80665)),
+    FixedLagSmoother::Status::kInitialized);
+  ASSERT_EQ(
+    smoother.addImu(0.1, Eigen::Vector3d::Zero(), Eigen::Vector3d(0.0, 0.0, 9.80665)),
+    FixedLagSmoother::Status::kApplied);
+  ASSERT_EQ(
+    smoother.addImu(0.05, Eigen::Vector3d::Zero(), Eigen::Vector3d(0.0, 0.0, 9.80665)),
+    FixedLagSmoother::Status::kReverseImu);
+
+  const Eigen::Vector3d variance(0.1, 0.1, 0.1);
+  const Eigen::Vector3d position(0.1, 0.0, 0.0);
+  ASSERT_EQ(
+    smoother.applyMeasurement(0.1, 7U, positionUpdate(position, variance)),
+    FixedLagSmoother::Status::kApplied);
+  ASSERT_EQ(
+    smoother.applyMeasurement(0.1, 7U, positionUpdate(position, variance)),
+    FixedLagSmoother::Status::kDuplicate);
+  EXPECT_EQ(smoother.counters().duplicate, 1U);
+  EXPECT_EQ(smoother.counters().reverse_imu, 1U);
+}
+
+// Subsampling (node_subsample > 1) must keep the smoother near the exact
+// per-IMU result: composed transition/Qd over a subsample interval reproduces
+// the same smoothed trajectory within a small tolerance while shrinking the
+// window and the per-step backward-pass cost.
+TEST(FixedLagSmoother, SubsampledMatchesPerImu)
+{
+  const Eigen::Vector3d variance(0.2, 0.2, 0.2);
+
+  EKFEstimator estimator_full;
+  configure(estimator_full);
+  FixedLagSmoother full(estimator_full, -1.0);
+
+  EKFEstimator estimator_sub;
+  configure(estimator_sub);
+  FixedLagSmoother sub(estimator_sub, -1.0);
+  ASSERT_TRUE(sub.setNodeSubsample(4U));
+
+  for (int i = 0; i <= 200; ++i) {
+    const double t = 0.01 * i;
+    const Eigen::Vector3d true_position(0.5 * t, 0.1 * t, 0.0);
+    const auto full_status = full.addImu(
+      t, Eigen::Vector3d::Zero(), Eigen::Vector3d(0.0, 0.0, 9.80665));
+    const auto sub_status = sub.addImu(
+      t, Eigen::Vector3d::Zero(), Eigen::Vector3d(0.0, 0.0, 9.80665));
+    ASSERT_TRUE(
+      full_status == FixedLagSmoother::Status::kInitialized ||
+      full_status == FixedLagSmoother::Status::kApplied);
+    ASSERT_TRUE(
+      sub_status == FixedLagSmoother::Status::kInitialized ||
+      sub_status == FixedLagSmoother::Status::kApplied ||
+      sub_status == FixedLagSmoother::Status::kEmitted);
+    if (i > 0 && i % 20 == 0) {
+      ASSERT_EQ(
+        full.applyMeasurement(
+          t, static_cast<std::uint64_t>(i),
+          positionUpdate(true_position, variance)),
+        FixedLagSmoother::Status::kApplied);
+      ASSERT_EQ(
+        sub.applyMeasurement(
+          t, static_cast<std::uint64_t>(i),
+          positionUpdate(true_position, variance)),
+        FixedLagSmoother::Status::kApplied);
+    }
+  }
+
+  const auto full_smoothed = full.smoothAll();
+  const auto sub_smoothed = sub.smoothAll();
+  ASSERT_FALSE(full_smoothed.empty());
+  ASSERT_FALSE(sub_smoothed.empty());
+  EXPECT_LE(sub.nodeCount(), full.nodeCount());
+  EXPECT_GT(full.nodeCount(), 100U);
+
+  auto mean_error = [](const std::vector<FixedLagSmoother::SmoothedNode> & traj) {
+      double sum = 0.0;
+      for (const auto & node : traj) {
+        const Eigen::Vector3d truth(0.5 * node.time, 0.1 * node.time, 0.0);
+        sum += (node.state.position - truth).norm();
+      }
+      return traj.empty() ? 0.0 : sum / static_cast<double>(traj.size());
+    };
+  const double full_error = mean_error(full_smoothed);
+  const double sub_error = mean_error(sub_smoothed);
+  // The subsampled oracle must stay close to the per-IMU oracle.
+  EXPECT_LT(sub_error, full_error + 0.05);
+  EXPECT_LT(sub_error, 0.10);
+}

--- a/kalman_filter_localization_ros2/param/ekf.yaml
+++ b/kalman_filter_localization_ros2/param/ekf.yaml
@@ -20,6 +20,13 @@ ekf_localization:
       enable_measurement_replay: false
       measurement_history_duration_sec: 1.0
       max_future_measurement_wait_sec: 0.5
+      # Optional offline fixed-lag RTS smoother oracle (requires replay): publishes
+      # /ekf_localization/smoothed_pose re-conditioned on future measurements.
+      # fixed_lag_node_subsample records one node every N IMU samples, shrinking
+      # the RTS window so the backward pass stays real-time at IMU rate.
+      enable_fixed_lag_smoothing: false
+      fixed_lag_duration_sec: 5.0
+      fixed_lag_node_subsample: 1
       # gnss_navsatfix_origin_latitude: 35.0
       # gnss_navsatfix_origin_longitude: 139.0
       # gnss_navsatfix_origin_altitude: 0.0

--- a/kalman_filter_localization_ros2/param/profiles/research_smoothing.yaml
+++ b/kalman_filter_localization_ros2/param/profiles/research_smoothing.yaml
@@ -1,0 +1,27 @@
+ekf_localization:
+  ros__parameters:
+    use_nonholonomic_constraint: false
+    var_nhc_lateral_velocity: 0.05
+    var_nhc_vertical_velocity: 0.02
+    use_zupt: false
+    use_zihr: false
+    use_flat_ground: false
+    var_zupt_velocity: 0.01
+    var_zihr_gyro: 0.00001
+    initial_imu_gyro_bias_covariance: 0.01
+    use_continuous_process_noise_density: false
+    use_second_order_state_transition: false
+    use_second_order_process_noise: false
+    propagation_model: "fast"
+    enable_measurement_replay: true
+    measurement_history_duration_sec: 0.6
+    max_future_measurement_wait_sec: 5.0
+    input_reorder_window_sec: 0.0
+    compensate_gnss_delay: false
+    gnss_position_robust_loss: "huber"
+    gnss_position_robust_tuning: 2.5
+    max_gnss_position_robust_variance_scale: 100.0
+    gnss_navsatfix_use_position_covariance: true
+    enable_fixed_lag_smoothing: true
+    fixed_lag_duration_sec: 5.0
+    fixed_lag_node_subsample: 10

--- a/kalman_filter_localization_ros2/src/ekf_localization_component.cpp
+++ b/kalman_filter_localization_ros2/src/ekf_localization_component.cpp
@@ -79,6 +79,7 @@
 
 #include <kalman_filter_localization/core/ekf_estimator.hpp>
 #include <kalman_filter_localization/core/eskf_replay.hpp>
+#include <kalman_filter_localization/core/fixed_lag_smoother.hpp>
 #include <kalman_filter_localization/core/imu_initializer.hpp>
 #include <kalman_filter_localization/core/measurement_quality.hpp>
 #include <kalman_filter_localization/core/odometry.hpp>
@@ -143,6 +144,14 @@ Eigen::Vector3d getRpyRadFromQuaternion(const Eigen::Quaterniond & q_in)
 double stampToSec(const builtin_interfaces::msg::Time & stamp)
 {
   return static_cast<double>(stamp.sec) + static_cast<double>(stamp.nanosec) * 1e-9;
+}
+
+builtin_interfaces::msg::Time stampFromSec(const double sec)
+{
+  builtin_interfaces::msg::Time stamp;
+  stamp.sec = static_cast<int32_t>(std::floor(sec));
+  stamp.nanosec = static_cast<uint32_t>((sec - std::floor(sec)) * 1e9);
+  return stamp;
 }
 
 Eigen::Matrix3d odometryPositionCovariance(
@@ -763,11 +772,12 @@ struct EkfLocalizationComponent::Impl
     drainBufferedInputs(false);
   }
 
-  bool applyInitialCovariance(
+  bool applyInitialCovarianceTo(
+    core::EKFEstimator & estimator,
     const Eigen::Vector3d & position_variance,
     const Eigen::Vector3d & attitude_variance)
   {
-    return ekf_.setInitialErrorStateCovariance(
+    return estimator.setInitialErrorStateCovariance(
       position_variance,
       Eigen::Vector3d(
         initial_velocity_variance_xy_, initial_velocity_variance_xy_,
@@ -777,15 +787,71 @@ struct EkfLocalizationComponent::Impl
       Eigen::Vector3d::Constant(initial_imu_acc_bias_covariance_));
   }
 
-  bool applyConfiguredInitialCovariance()
+  bool applyInitialCovariance(
+    const Eigen::Vector3d & position_variance,
+    const Eigen::Vector3d & attitude_variance)
   {
-    return applyInitialCovariance(
+    return applyInitialCovarianceTo(ekf_, position_variance, attitude_variance);
+  }
+
+  bool applyConfiguredInitialCovarianceTo(core::EKFEstimator & estimator)
+  {
+    return applyInitialCovarianceTo(
+      estimator,
       Eigen::Vector3d(
         initial_position_variance_xy_, initial_position_variance_xy_,
         initial_position_variance_z_),
       Eigen::Vector3d(
         initial_attitude_variance_rp_, initial_attitude_variance_rp_,
         initial_attitude_variance_yaw_));
+  }
+
+  bool applyConfiguredInitialCovariance()
+  {
+    return applyConfiguredInitialCovarianceTo(ekf_);
+  }
+
+  // Applies the process-model, noise, bias, gravity, and initial-covariance
+  // settings to an estimator. The node's main EKF and the fixed-lag smoother run
+  // with identical dynamics so the oracle sees the same model as the filter.
+  void configureEstimator(
+    core::EKFEstimator & estimator,
+    const core::EKFEstimator::PropagationModel propagation_model)
+  {
+    estimator.setVarImuGyro(var_imu_w_);
+    estimator.setVarImuAcc(var_imu_acc_);
+    estimator.setPropagationModel(propagation_model);
+    estimator.setVarImuGyroBias(var_imu_gyro_bias_);
+    if (!estimator.setInitialGyroBiasCovariance(initial_imu_gyro_bias_covariance_)) {
+      RCLCPP_WARN(
+        node_.get_logger(),
+        "invalid parameter initial_imu_gyro_bias_covariance=%f. fallback to default=0.0",
+        initial_imu_gyro_bias_covariance_);
+    }
+    estimator.setTauGyroBias(tau_gyro_bias_sec_);
+    estimator.setVarImuAccBias(var_imu_acc_bias_);
+    if (!estimator.setInitialAccelBiasCovariance(initial_imu_acc_bias_covariance_)) {
+      RCLCPP_WARN(
+        node_.get_logger(),
+        "invalid parameter initial_imu_acc_bias_covariance=%f. fallback to default=0.0",
+        initial_imu_acc_bias_covariance_);
+    }
+    estimator.setTauAccBias(tau_acc_bias_sec_);
+    if (!estimator.setMaxPredictionDtSec(max_imu_dt_sec_)) {
+      RCLCPP_WARN(
+        node_.get_logger(),
+        "invalid parameter max_imu_dt_sec=%f. fallback to default=%f",
+        max_imu_dt_sec_, estimator.getMaxPredictionDtSec());
+    }
+    if (!estimator.setGravityZ(gravity_mps2_)) {
+      RCLCPP_WARN(
+        node_.get_logger(),
+        "invalid parameter gravity_mps2=%f. fallback to default=%f",
+        gravity_mps2_, estimator.getGravityZ());
+    }
+    if (!applyConfiguredInitialCovarianceTo(estimator)) {
+      throw std::invalid_argument("failed to apply configured initial covariance");
+    }
   }
 
   void init()
@@ -865,6 +931,12 @@ struct EkfLocalizationComponent::Impl
     node_.declare_parameter("max_future_measurement_wait_sec", 0.5);
     node_.get_parameter(
       "max_future_measurement_wait_sec", max_future_measurement_wait_sec_);
+    node_.declare_parameter("enable_fixed_lag_smoothing", false);
+    node_.get_parameter("enable_fixed_lag_smoothing", enable_fixed_lag_smoothing_);
+    node_.declare_parameter("fixed_lag_duration_sec", 5.0);
+    node_.get_parameter("fixed_lag_duration_sec", fixed_lag_duration_sec_);
+    node_.declare_parameter("fixed_lag_node_subsample", 1);
+    node_.get_parameter("fixed_lag_node_subsample", fixed_lag_node_subsample_);
     node_.declare_parameter("var_imu_w", 0.01);
     node_.get_parameter("var_imu_w", var_imu_w_);
     node_.declare_parameter("var_imu_acc", 0.01);
@@ -1867,6 +1939,26 @@ struct EkfLocalizationComponent::Impl
     RCLCPP_INFO(
       node_.get_logger(), "vehicle model: plugin='%s' model='%s'",
       vehicle_model_plugin_.c_str(), vehicle_model_->name().c_str());
+    // Private vehicle model / stationary detector for the fixed-lag smoothing
+    // forward track so per-IMU corrections run independently of the main filter.
+    if (enable_fixed_lag_smoothing_) {
+      try {
+        smoother_vehicle_model_ =
+          vehicle_model_loader_.createSharedInstance(vehicle_model_plugin_);
+      } catch (const pluginlib::PluginlibException & exception) {
+        throw std::invalid_argument(
+                std::string("failed to load smoother vehicle_model_plugin='") +
+                vehicle_model_plugin_ + "': " + exception.what());
+      }
+      if (!smoother_vehicle_model_ ||
+        !smoother_vehicle_model_->configure(vehicle_model_config))
+      {
+        throw std::invalid_argument(
+                std::string("smoother vehicle model plugin rejected configuration: ") +
+                (smoother_vehicle_model_ ? smoother_vehicle_model_->name() : std::string("null")));
+      }
+      smoother_stationary_detector_ = core::StationaryDetector(stationary_config);
+    }
     core::GnssReacquisitionGate::Config reacquisition_config;
     reacquisition_config.outage_duration_sec = gnss_position_reacquisition_dt_sec_ > 0.0 ?
       gnss_position_reacquisition_dt_sec_ : 1.0;
@@ -1931,37 +2023,21 @@ struct EkfLocalizationComponent::Impl
       throw std::invalid_argument(
               "propagation_model must be one of: legacy, fast, exact");
     }
-    ekf_.setPropagationModel(propagation_model);
-    ekf_.setVarImuGyroBias(var_imu_gyro_bias_);
-    if (!ekf_.setInitialGyroBiasCovariance(initial_imu_gyro_bias_covariance_)) {
-      RCLCPP_WARN(
-        node_.get_logger(),
-        "invalid parameter initial_imu_gyro_bias_covariance=%f. fallback to default=0.0",
-        initial_imu_gyro_bias_covariance_);
-    }
-    ekf_.setTauGyroBias(tau_gyro_bias_sec_);
-    ekf_.setVarImuAccBias(var_imu_acc_bias_);
-    if (!ekf_.setInitialAccelBiasCovariance(initial_imu_acc_bias_covariance_)) {
-      RCLCPP_WARN(
-        node_.get_logger(),
-        "invalid parameter initial_imu_acc_bias_covariance=%f. fallback to default=0.0",
-        initial_imu_acc_bias_covariance_);
-    }
-    ekf_.setTauAccBias(tau_acc_bias_sec_);
-    if (!ekf_.setMaxPredictionDtSec(max_imu_dt_sec_)) {
-      RCLCPP_WARN(
-        node_.get_logger(),
-        "invalid parameter max_imu_dt_sec=%f. fallback to default=%f",
-        max_imu_dt_sec_, ekf_.getMaxPredictionDtSec());
-    }
-    if (!ekf_.setGravityZ(gravity_mps2_)) {
-      RCLCPP_WARN(
-        node_.get_logger(),
-        "invalid parameter gravity_mps2=%f. fallback to default=%f",
-        gravity_mps2_, ekf_.getGravityZ());
-    }
-    if (!applyConfiguredInitialCovariance()) {
-      throw std::invalid_argument("failed to apply configured initial covariance");
+    configureEstimator(ekf_, propagation_model);
+    configureEstimator(smoother_ekf_, propagation_model);
+    if (enable_fixed_lag_smoothing_) {
+      if (!(fixed_lag_duration_sec_ > 0.0) || !std::isfinite(fixed_lag_duration_sec_)) {
+        throw std::invalid_argument("fixed_lag_duration_sec must be finite and positive");
+      }
+      if (!enable_measurement_replay_) {
+        RCLCPP_WARN(
+          node_.get_logger(),
+          "enable_fixed_lag_smoothing requires enable_measurement_replay=true; "
+          "smoother output is disabled without the in-order sensor-time measurement feed");
+      }
+      smoother_ = std::make_unique<core::FixedLagSmoother>(
+        smoother_ekf_, fixed_lag_duration_sec_, max_future_measurement_wait_sec_,
+        static_cast<std::size_t>(std::max(fixed_lag_node_subsample_, 1)));
     }
     var_gnss_ << var_gnss_xy_, var_gnss_xy_, var_gnss_z_;
     var_gnss_velocity_ << var_gnss_velocity_xy_, var_gnss_velocity_xy_, var_gnss_velocity_z_;
@@ -1976,6 +2052,12 @@ struct EkfLocalizationComponent::Impl
       output_pose_name, rclcpp::QoS(output_qos_depth_));
     current_odometry_pub_ =
       node_.create_publisher<nav_msgs::msg::Odometry>(output_odometry_topic_, 10);
+    if (enable_fixed_lag_smoothing_) {
+      const std::string smoothed_pose_name = node_.get_name() + std::string("/smoothed_pose");
+      smoothed_pose_pub_ =
+        node_.create_publisher<geometry_msgs::msg::PoseStamped>(
+        smoothed_pose_name, rclcpp::QoS(output_qos_depth_));
+    }
     if (publish_tf_) {
       tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(node_);
     }
@@ -2051,6 +2133,10 @@ struct EkfLocalizationComponent::Impl
           current_pose_.pose.orientation.y,
           current_pose_.pose.orientation.z);
         ekf_.setState(state);
+        if (smoother_) {
+          smoother_ekf_.setState(state);
+          smoother_->reset();
+        }
         const bool covariance_applied = use_message_covariance ?
           applyInitialCovariance(
           Eigen::Vector3d(
@@ -2650,8 +2736,22 @@ struct EkfLocalizationComponent::Impl
   core::EskfReplay::MeasurementFunction makeImuReplayCorrection(
     const sensor_msgs::msg::Imu & imu_msg, const double sensor_time)
   {
+    return makeImuCorrection(imu_msg, sensor_time, stationary_detector_, *vehicle_model_);
+  }
+
+  // Builds a per-IMU correction function (orientation / flat-ground / NHC /
+  // ZUPT / ZIHR / bias-observability gating) against a caller-provided
+  // stationary detector and vehicle model. The main replay track uses the
+  // node's shared detector/model; the fixed-lag smoothing track uses its own
+  // private instances so the two forward runs stay independent.
+  core::EskfReplay::MeasurementFunction makeImuCorrection(
+    const sensor_msgs::msg::Imu & imu_msg, const double sensor_time,
+    core::StationaryDetector & stationary_detector,
+    core::VehicleModel & vehicle_model)
+  {
     const auto plan = std::make_shared<ImuReplayPlan>();
-    return [this, imu_msg, sensor_time, plan](core::EKFEstimator & estimator) {
+    return [this, imu_msg, sensor_time, plan, &stationary_detector,
+             &vehicle_model](core::EKFEstimator & estimator) {
              using UpdateStatus = core::EKFEstimator::ObservationUpdateStatus;
              UpdateStatus status = UpdateStatus::kUpdated;
              const Eigen::Vector3d angular_velocity(
@@ -2661,7 +2761,7 @@ struct EkfLocalizationComponent::Impl
                imu_msg.linear_acceleration.x, imu_msg.linear_acceleration.y,
                imu_msg.linear_acceleration.z);
              if (!plan->initialized) {
-               const auto stationary_state = stationary_detector_.update(
+               const auto stationary_state = stationary_detector.update(
                  sensor_time, angular_velocity, acceleration,
                  estimator.getVelocity().norm(), gravity_mps2_);
                plan->apply_zupt = use_zupt_ &&
@@ -2676,7 +2776,7 @@ struct EkfLocalizationComponent::Impl
                vehicle_model_input.body_velocity = body_velocity;
                vehicle_model_input.yaw_rate_radps = imu_msg.angular_velocity.z;
                vehicle_model_input.lateral_acceleration_mps2 = imu_msg.linear_acceleration.y;
-               const auto vehicle_model_output = vehicle_model_->evaluate(vehicle_model_input);
+               const auto vehicle_model_output = vehicle_model.evaluate(vehicle_model_input);
                plan->apply_nhc = vehicle_model_output.valid &&
                  vehicle_model_output.apply_nonholonomic_constraint &&
                  std::isfinite(vehicle_model_output.nhc_variance_scale) &&
@@ -2760,6 +2860,22 @@ struct EkfLocalizationComponent::Impl
            };
   }
 
+  void feedSmootherMeasurement(
+    const double sensor_time, const std::uint64_t measurement_id,
+    const core::EskfReplay::Status replay_status,
+    const core::EskfReplay::MeasurementFunction & update)
+  {
+    if (!smoother_ || !enable_fixed_lag_smoothing_) {
+      return;
+    }
+    if (replay_status != core::EskfReplay::Status::kApplied &&
+      replay_status != core::EskfReplay::Status::kQueuedFuture)
+    {
+      return;
+    }
+    (void)smoother_->applyMeasurement(sensor_time, measurement_id, update);
+  }
+
   core::EskfReplay::Status applyReplayMeasurement(
     const builtin_interfaces::msg::Time & stamp, const std::uint8_t source,
     core::EskfReplay::MeasurementFunction update, const double time_offset_sec = 0.0)
@@ -2769,8 +2885,10 @@ struct EkfLocalizationComponent::Impl
     const std::uint64_t stamp_bits = static_cast<std::uint64_t>(stampToNanoseconds(stamp));
     const std::uint64_t measurement_id =
       (static_cast<std::uint64_t>(source) << 56U) ^ stamp_bits;
+    const auto smoother_update = update;
     const auto status = replay_->applyMeasurement(
       sensor_time, arrival_time, measurement_id, std::move(update));
+    feedSmootherMeasurement(sensor_time, measurement_id, status, smoother_update);
     if (debug_replay_timing_pub_) {
       const auto & trace = replay_->lastTimingTrace();
       std_msgs::msg::Float64MultiArray message;
@@ -2837,6 +2955,10 @@ struct EkfLocalizationComponent::Impl
         state.velocity.setZero();
         state.gyro_bias = result.gyro_bias;
         ekf_.setState(state);
+        if (smoother_) {
+          smoother_ekf_.setState(state);
+          smoother_->reset();
+        }
         has_previous_time_imu_ = false;
         previous_time_imu_ = 0.0;
         replay_->reset();
@@ -2869,6 +2991,28 @@ struct EkfLocalizationComponent::Impl
         current_time_imu, gyro, linear_acceleration,
         first_sample ? core::EskfReplay::MeasurementFunction{} :
         makeImuReplayCorrection(imu_msg, current_time_imu));
+      if (smoother_ && enable_fixed_lag_smoothing_) {
+        const bool smoother_first = smoother_->counters().imu_samples == 0U;
+        const auto smoother_status = smoother_->addImu(
+          current_time_imu, gyro, linear_acceleration,
+          smoother_first ? core::EskfReplay::MeasurementFunction{} :
+          makeImuCorrection(
+            imu_msg, current_time_imu, smoother_stationary_detector_,
+            *smoother_vehicle_model_));
+        if (smoother_status != core::FixedLagSmoother::Status::kApplied &&
+          smoother_status != core::FixedLagSmoother::Status::kInitialized &&
+          smoother_status != core::FixedLagSmoother::Status::kEmitted)
+        {
+          RCLCPP_WARN_THROTTLE(
+            node_.get_logger(), clock_, 5000,
+            "smoother IMU rejected: status=%d imu_samples=%llu time=%.9f latest=%.9f "
+            "max_dt=%f",
+            static_cast<int>(smoother_status),
+            static_cast<std::uint64_t>(smoother_->counters().imu_samples),
+            current_time_imu, smoother_->latestTime(),
+            smoother_ekf_.getMaxPredictionDtSec());
+        }
+      }
       if (status == core::EskfReplay::Status::kInitialized ||
         status == core::EskfReplay::Status::kApplied)
       {
@@ -4391,6 +4535,35 @@ struct EkfLocalizationComponent::Impl
       std::fabs(dyaw), raw_nis, computeYawNis(dyaw, yaw_variance, covariance));
   }
 
+  void publishSmoothedPose()
+  {
+    core::FixedLagSmoother::SmoothedNode node;
+    std::size_t published = 0;
+    while (smoother_->popSmoothed(node)) {
+      published++;
+      smoothed_pose_.header.stamp = stampFromSec(node.time);
+      smoothed_pose_.header.frame_id = reference_frame_id_;
+      smoothed_pose_.pose.position.x = node.state.position.x();
+      smoothed_pose_.pose.position.y = node.state.position.y();
+      smoothed_pose_.pose.position.z = node.state.position.z();
+      smoothed_pose_.pose.orientation.x = node.state.orientation.x();
+      smoothed_pose_.pose.orientation.y = node.state.orientation.y();
+      smoothed_pose_.pose.orientation.z = node.state.orientation.z();
+      smoothed_pose_.pose.orientation.w = node.state.orientation.w();
+      smoothed_pose_pub_->publish(smoothed_pose_);
+    }
+    if (published > 0U) {
+      RCLCPP_INFO_THROTTLE(
+        node_.get_logger(), clock_, 5000,
+        "published %zu smoothed poses; smoother nodes=%zu counters={imu=%llu "
+        "applied=%llu emitted=%llu}",
+        published, smoother_->nodeCount(),
+        static_cast<std::uint64_t>(smoother_->counters().imu_samples),
+        static_cast<std::uint64_t>(smoother_->counters().measurements_applied),
+        static_cast<std::uint64_t>(smoother_->counters().smoothed_emitted));
+    }
+  }
+
   void broadcastPose()
   {
     if (!initial_pose_received_ || !has_received_input_) {
@@ -4419,6 +4592,9 @@ struct EkfLocalizationComponent::Impl
     current_pose_pub_->publish(current_pose_);
     ++published_pose_count_;
 
+    if (smoother_ && smoothed_pose_pub_) {
+      publishSmoothedPose();
+    }
     const auto state = ekf_.getState();
     const Eigen::MatrixXd covariance = ekf_.getCovariance();
     nav_msgs::msg::Odometry odometry_msg;
@@ -4512,6 +4688,9 @@ struct EkfLocalizationComponent::Impl
   bool enable_measurement_replay_{false};
   double measurement_history_duration_sec_{1.0};
   double max_future_measurement_wait_sec_{0.5};
+  bool enable_fixed_lag_smoothing_{false};
+  double fixed_lag_duration_sec_{5.0};
+  int fixed_lag_node_subsample_{1};
 
   double var_imu_w_{0.0};
   double var_imu_acc_{0.0};
@@ -4698,6 +4877,7 @@ struct EkfLocalizationComponent::Impl
   input_reorder_queue_;
 
   geometry_msgs::msg::PoseStamped current_pose_;
+  geometry_msgs::msg::PoseStamped smoothed_pose_;
   rclcpp::Time current_stamp_;
   rclcpp::Time latest_imu_stamp_;
 
@@ -4734,6 +4914,10 @@ struct EkfLocalizationComponent::Impl
   std::shared_ptr<core::VehicleModel> vehicle_model_;
   bool stationary_initialization_complete_{false};
   std::unique_ptr<core::EskfReplay> replay_;
+  core::EKFEstimator smoother_ekf_;
+  std::unique_ptr<core::FixedLagSmoother> smoother_;
+  core::StationaryDetector smoother_stationary_detector_;
+  std::shared_ptr<core::VehicleModel> smoother_vehicle_model_;
 
   rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr sub_initial_pose_;
   rclcpp::Subscription<geometry_msgs::msg::PoseWithCovarianceStamped>::SharedPtr
@@ -4748,6 +4932,7 @@ struct EkfLocalizationComponent::Impl
     sub_wheel_speed_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr drain_input_buffer_service_;
   rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr current_pose_pub_;
+  rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr smoothed_pose_pub_;
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr current_odometry_pub_;
   rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr current_gyro_bias_pub_;
   rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>::SharedPtr current_accel_bias_pub_;

--- a/plan.md
+++ b/plan.md
@@ -246,7 +246,12 @@ Phase 0--6 完了後、同じ benchmark で必要性を判定する。
 
 - [ ] invariant EKF/FEJ による unobservable yaw/translation の consistency 改善。
 - [ ] online wheel scale、lever arm、time offset calibration。
-- [ ] fixed-lag smoother または GTSAM を offline oracle とした EKF 誤差分析。
+- [ ] invariant EKF/FEJ による unobservable yaw/translation の consistency 改善。
+- [x] fixed-lag smoother を offline oracle とした EKF 誤差分析（`core::FixedLagSmoother`:
+      RTS backward pass、fixed-lag/batch 両対応、node subsampling で実時間動作。
+      `ekf_localization_node` に `enable_fixed_lag_smoothing` と
+      `/ekf_localization/smoothed_pose` を追加。実 bag で GT 誤差が filter
+      15.4 m → smoother 1.9 m に改善。詳細は `docs/fixed_lag_smoothing.md`）。
 - [ ] raw GNSS pseudorange/Doppler の tightly coupled fusion と RAIM/NLOS 対応。
 - [ ] LiDAR/VIO/radar velocity aid。
 


### PR DESCRIPTION
## Summary

Implements a fixed-lag Rauch-Tung-Striebel (RTS) smoother over the ESKF as an offline oracle for EKF error analysis (plan.md Phase 7).

## Changes

- `EKFEstimator::getLastDiscreteModel()`: exposes the discrete transition / process-covariance pair `(Phi, Qd)` used by each prediction step.
- New `core::FixedLagSmoother`: fixed-lag and batch RTS backward passes, with node subsampling that composes per-step discrete models so the backward pass stays real-time at IMU rate. Measurements are fused at node boundaries to keep predicted states measurement-free.
- `ekf_localization_node`: adds `enable_fixed_lag_smoothing` / `fixed_lag_duration_sec` / `fixed_lag_node_subsample` and publishes `/ekf_localization/smoothed_pose`. The smoothing forward track runs its own stationary detector and vehicle model so per-IMU corrections (orientation/NHC/ZUPT/ZIHR) apply independently of the main filter.
- Unit tests: covariance non-increase, batch equivalence, error reduction, fixed-lag emission order, rejection handling, subsample consistency.
- Docs: `docs/fixed_lag_smoothing.md`.

## Validation

- All core + ROS2 unit tests and lint (cpplint/uncrustify/pytest) pass.
- Applanix open-sky segment: GNSS ground-truth 3D error reduced from 15.4 m (filter) to 1.9 m (smoothed).